### PR TITLE
(Chore) Remove `console.log` and `debugger`

### DIFF
--- a/src/utils/modals/GenericModal/index.tsx
+++ b/src/utils/modals/GenericModal/index.tsx
@@ -17,7 +17,7 @@ const StyledButton = styled.button`
   height: 26px;
 
   span {
-    margin-right: 0px;
+    margin-right: 0;
   }
 
   :focus {
@@ -96,8 +96,7 @@ const GenericModal = ({
   smallHeight,
 }: GenericModalProps & { smallHeight: boolean }) => {
   const classes = useStyles({ smallHeight });
-  console.log('smallHeight: ', smallHeight);
-  debugger;
+
   return (
     <Modal open className={classes.modal} title="GenericModal">
       <div className={cn(classes.paper)}>
@@ -127,4 +126,5 @@ const MediaModal = (props: GenericModalProps): React.ReactElement => (
     {(matches) => <GenericModal {...props} smallHeight={matches} />}
   </Media>
 );
+
 export default MediaModal;


### PR DESCRIPTION
I'm getting a sort of annoying messages when using the `GenericModal` component

![image](https://user-images.githubusercontent.com/3315606/88969538-624f3f00-d287-11ea-887f-81390865d1b6.png)

I don't think they're necessary on production code.