### PR TITLE
Refactor: AddressInfo and EtherscanButton

### DIFF
--- a/src/ethereum/EthHashInfo/ethHashInfo.stories.tsx
+++ b/src/ethereum/EthHashInfo/ethHashInfo.stories.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
-import AddressInfo from './index';
+import EthHashInfo from './index';
 import { EllipsisMenuItem } from '../..';
 
 export default {
   title: 'Ethereum/Eth hash Info',
-  component: AddressInfo,
+  component: EthHashInfo,
   parameters: {
     componentSubtitle: 'Display Address/Tx information.',
   },
@@ -13,22 +13,22 @@ export default {
 
 const hash = '0x69904ff6d6100799344E5C9A2806936318F6ba4f';
 
-export const Address = (): React.ReactElement => <AddressInfo hash={hash} />;
+export const Address = (): React.ReactElement => <EthHashInfo hash={hash} />;
 
 export const WithShortAddress = (): React.ReactElement => (
-  <AddressInfo hash={hash} shortenHash={4} />
+  <EthHashInfo hash={hash} shortenHash={4} />
 );
 
 export const WithName = (): React.ReactElement => (
-  <AddressInfo hash={hash} name="Owner 1" />
+  <EthHashInfo hash={hash} name="Owner 1" />
 );
 
 export const WithIdenticon = (): React.ReactElement => (
-  <AddressInfo hash={hash} showIdenticon shortenHash={4} />
+  <EthHashInfo hash={hash} showIdenticon shortenHash={4} />
 );
 
 export const WithButtons = (): React.ReactElement => (
-  <AddressInfo
+  <EthHashInfo
     hash={hash}
     name="Owner 1"
     showIdenticon
@@ -44,7 +44,7 @@ export const WithMenu = (): React.ReactElement => {
     { label: 'Edit Address book entry', onClick: console.log },
   ];
   return (
-    <AddressInfo
+    <EthHashInfo
       hash={hash}
       name="Owner 1"
       showIdenticon

--- a/src/ethereum/EthHashInfo/ethHashInfo.stories.tsx
+++ b/src/ethereum/EthHashInfo/ethHashInfo.stories.tsx
@@ -4,39 +4,37 @@ import AddressInfo from './index';
 import { EllipsisMenuItem } from '../..';
 
 export default {
-  title: 'Ethereum/Address Info',
+  title: 'Ethereum/Eth hash Info',
   component: AddressInfo,
   parameters: {
-    componentSubtitle: 'Display Address information.',
+    componentSubtitle: 'Display Address/Tx information.',
   },
 };
 
-const address = '0x69904ff6d6100799344E5C9A2806936318F6ba4f';
+const hash = '0x69904ff6d6100799344E5C9A2806936318F6ba4f';
 
-export const Address = (): React.ReactElement => (
-  <AddressInfo address={address} />
-);
+export const Address = (): React.ReactElement => <AddressInfo hash={hash} />;
 
 export const WithShortAddress = (): React.ReactElement => (
-  <AddressInfo address={address} shortenAddress={4} />
+  <AddressInfo hash={hash} shortenHash={4} />
 );
 
 export const WithName = (): React.ReactElement => (
-  <AddressInfo address={address} name="Owner 1" />
+  <AddressInfo hash={hash} name="Owner 1" />
 );
 
 export const WithIdenticon = (): React.ReactElement => (
-  <AddressInfo address={address} showIdenticon shortenAddress={4} />
+  <AddressInfo hash={hash} showIdenticon shortenHash={4} />
 );
 
 export const WithButtons = (): React.ReactElement => (
   <AddressInfo
-    address={address}
+    hash={hash}
     name="Owner 1"
     showIdenticon
     showCopyBtn
     showEtherscanBtn
-    shortenAddress={4}
+    shortenHash={4}
   />
 );
 
@@ -47,13 +45,13 @@ export const WithMenu = (): React.ReactElement => {
   ];
   return (
     <AddressInfo
-      address={address}
+      hash={hash}
       name="Owner 1"
       showIdenticon
       showCopyBtn
       showEtherscanBtn
       menuItems={items}
-      shortenAddress={4}
+      shortenHash={4}
     />
   );
 };

--- a/src/ethereum/EthHashInfo/index.tsx
+++ b/src/ethereum/EthHashInfo/index.tsx
@@ -40,11 +40,11 @@ const AddressContainer = styled.div`
 `;
 
 type Props = {
-  address: string;
+  hash: string;
   textColor?: ThemeColors;
   textSize?: ThemeTextSize;
   identiconSize?: ThemeIdenticonSize;
-  shortenAddress?: number;
+  shortenHash?: number;
   className?: string;
   name?: string;
   showIdenticon?: boolean;
@@ -54,14 +54,14 @@ type Props = {
   network?: Network;
 };
 
-const AddressInfo = ({
-  address,
+const EthHashInfo = ({
+  hash,
   name,
   textColor = 'text',
   textSize = 'lg',
   identiconSize = 'md',
   className,
-  shortenAddress,
+  shortenHash,
   showIdenticon,
   showCopyBtn,
   menuItems,
@@ -71,7 +71,7 @@ const AddressInfo = ({
   <StyledContainer className={className}>
     {showIdenticon && (
       <IdenticonContainer>
-        <Identicon address={address} size={identiconSize} />
+        <Identicon address={hash} size={identiconSize} />
       </IdenticonContainer>
     )}
 
@@ -83,18 +83,16 @@ const AddressInfo = ({
       )}
       <AddressContainer>
         <Text size={textSize} color={textColor}>
-          {shortenAddress
-            ? textShortener(address, shortenAddress + 2, shortenAddress)
-            : address}
+          {shortenHash
+            ? textShortener(hash, shortenHash + 2, shortenHash)
+            : hash}
         </Text>
-        {showCopyBtn && <CopyToClipboardBtn textToCopy={address} />}
-        {showEtherscanBtn && (
-          <EtherscanButton type="address" value={address} network={network} />
-        )}
+        {showCopyBtn && <CopyToClipboardBtn textToCopy={hash} />}
+        {showEtherscanBtn && <EtherscanButton value={hash} network={network} />}
         {menuItems && <EllipsisMenu menuItems={menuItems} />}
       </AddressContainer>
     </InfoContainer>
   </StyledContainer>
 );
 
-export default AddressInfo;
+export default EthHashInfo;

--- a/src/ethereum/EtherscanButton/index.stories.tsx
+++ b/src/ethereum/EtherscanButton/index.stories.tsx
@@ -18,16 +18,10 @@ export const SimpleEtherscanButton = (): React.ReactElement => (
   <>
     <StyledText size="md">An Address example</StyledText>
     <br />
-    <EtherscanButton
-      type="address"
-      value="0xda6786379ff88729264d31d472fa917f5e561443"
-    />
+    <EtherscanButton value="0xda6786379ff88729264d31d472fa917f5e561443" />
     <br />
     <StyledText size="md">A Transaction example</StyledText>
     <br />
-    <EtherscanButton
-      type="tx"
-      value="0xc276be3ffccc2398d3b82a0e375a94f67b8ad81c68f8625a5d516567dfe3de29"
-    />
+    <EtherscanButton value="0xc276be3ffccc2398d3b82a0e375a94f67b8ad81c68f8625a5d516567dfe3de29" />
   </>
 );

--- a/src/ethereum/EtherscanButton/index.tsx
+++ b/src/ethereum/EtherscanButton/index.tsx
@@ -26,17 +26,25 @@ const EtherscanButton = ({
 }: Props): React.ReactElement => {
   const type = value.length > 42 ? 'tx' : 'address';
 
-  const etherscanLink = `https://${getNetwork(
-    network
-  )}etherscan.io/${type}/${value}`;
+  const onClick = (
+    event:
+      | React.MouseEvent<HTMLAnchorElement>
+      | React.KeyboardEvent<HTMLAnchorElement>
+  ): void => {
+    event?.stopPropagation();
+    window.open(
+      `https://${getNetwork(network)}etherscan.io/${type}/${value}`,
+      '_blank'
+    );
+  };
 
   return (
     <StyledLink
       className={className}
       aria-label="Show details on Etherscan"
-      href={etherscanLink}
       rel="noopener noreferrer"
-      target="_blank">
+      onClick={onClick}
+      onKeyPress={onClick}>
       <Icon
         size="sm"
         color="icon"

--- a/src/ethereum/EtherscanButton/index.tsx
+++ b/src/ethereum/EtherscanButton/index.tsx
@@ -38,13 +38,20 @@ const EtherscanButton = ({
     );
   };
 
+  const onKeyDown = (event: React.KeyboardEvent<HTMLAnchorElement>): void => {
+    // prevents event from bubbling when `Enter` is pressed
+    if (event.keyCode === 13) {
+      event.stopPropagation();
+    }
+  };
+
   return (
     <StyledLink
       className={className}
       aria-label="Show details on Etherscan"
       rel="noopener noreferrer"
       onClick={onClick}
-      onKeyPress={onClick}>
+      onKeyPress={onKeyDown}>
       <Icon
         size="sm"
         color="icon"

--- a/src/ethereum/EtherscanButton/index.tsx
+++ b/src/ethereum/EtherscanButton/index.tsx
@@ -6,6 +6,7 @@ import { Network } from '../../typings/misc';
 
 const StyledLink = styled.a`
   display: inline-flex;
+  outline-color: ${({ theme }) => theme.colors.separator};
 `;
 
 type Props = {

--- a/src/ethereum/EtherscanButton/index.tsx
+++ b/src/ethereum/EtherscanButton/index.tsx
@@ -11,7 +11,6 @@ const StyledLink = styled.a`
 type Props = {
   className?: string;
   network?: Network;
-  type: 'address' | 'tx';
   value: string;
 };
 
@@ -22,10 +21,11 @@ const getNetwork = (network: Network) => {
 
 const EtherscanButton = ({
   className,
-  type,
   value,
   network = 'mainnet',
 }: Props): React.ReactElement => {
+  const type = value.length > 42 ? 'tx' : 'address';
+
   const etherscanLink = `https://${getNetwork(
     network
   )}etherscan.io/${type}/${value}`;

--- a/src/ethereum/EtherscanButton/index.tsx
+++ b/src/ethereum/EtherscanButton/index.tsx
@@ -28,7 +28,7 @@ const EtherscanButton = ({
   const type = value.length > 42 ? 'tx' : 'address';
 
   const onClick = (event: React.MouseEvent<HTMLAnchorElement>): void => {
-    event?.stopPropagation();
+    event.stopPropagation();
   };
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLAnchorElement>): void => {

--- a/src/ethereum/EtherscanButton/index.tsx
+++ b/src/ethereum/EtherscanButton/index.tsx
@@ -5,7 +5,7 @@ import { Icon } from '../..';
 import { Network } from '../../typings/misc';
 
 const StyledLink = styled.a`
-  display: flex;
+  display: inline-flex;
 `;
 
 type Props = {
@@ -26,16 +26,8 @@ const EtherscanButton = ({
 }: Props): React.ReactElement => {
   const type = value.length > 42 ? 'tx' : 'address';
 
-  const onClick = (
-    event:
-      | React.MouseEvent<HTMLAnchorElement>
-      | React.KeyboardEvent<HTMLAnchorElement>
-  ): void => {
+  const onClick = (event: React.MouseEvent<HTMLAnchorElement>): void => {
     event?.stopPropagation();
-    window.open(
-      `https://${getNetwork(network)}etherscan.io/${type}/${value}`,
-      '_blank'
-    );
   };
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLAnchorElement>): void => {
@@ -51,6 +43,8 @@ const EtherscanButton = ({
       aria-label="Show details on Etherscan"
       rel="noopener noreferrer"
       onClick={onClick}
+      href={`https://${getNetwork(network)}etherscan.io/${type}/${value}`}
+      target="_blank"
       onKeyPress={onKeyDown}>
       <Icon
         size="sm"

--- a/src/ethereum/index.ts
+++ b/src/ethereum/index.ts
@@ -1,2 +1,2 @@
-export { default as AddressInfo } from './AddressInfo';
+export { default as EthHashInfo } from './EthHashInfo';
 export { default as EtherscanButton } from './EtherscanButton';

--- a/src/utils/CopyToClipboardBtn/index.tsx
+++ b/src/utils/CopyToClipboardBtn/index.tsx
@@ -26,7 +26,12 @@ const CopyToClipboardBtn = ({
 }: Props): React.ReactElement => {
   const [clicked, setClicked] = useState<boolean>(false);
 
-  const onButtonClick = (): void => {
+  const onButtonClick = (
+    event:
+      | React.MouseEvent<HTMLButtonElement>
+      | React.KeyboardEvent<HTMLButtonElement>
+  ): void => {
+    event?.stopPropagation();
     copyTextToClipboard(textToCopy);
     setClicked(true);
   };
@@ -38,6 +43,7 @@ const CopyToClipboardBtn = ({
     <StyledButton
       className={className}
       onClick={onButtonClick}
+      onKeyPress={onButtonClick}
       onMouseLeave={onButtonBlur}>
       <Icon
         size="sm"

--- a/src/utils/CopyToClipboardBtn/index.tsx
+++ b/src/utils/CopyToClipboardBtn/index.tsx
@@ -31,9 +31,16 @@ const CopyToClipboardBtn = ({
       | React.MouseEvent<HTMLButtonElement>
       | React.KeyboardEvent<HTMLButtonElement>
   ): void => {
-    event?.stopPropagation();
+    event.stopPropagation();
     copyTextToClipboard(textToCopy);
     setClicked(true);
+  };
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>): void => {
+    // prevents event from bubbling when `Enter` is pressed
+    if (event.keyCode === 13) {
+      event.stopPropagation();
+    }
   };
 
   const onButtonBlur = (): number =>
@@ -43,7 +50,7 @@ const CopyToClipboardBtn = ({
     <StyledButton
       className={className}
       onClick={onButtonClick}
-      onKeyPress={onButtonClick}
+      onKeyPress={onKeyDown}
       onMouseLeave={onButtonBlur}>
       <Icon
         size="sm"

--- a/src/utils/CopyToClipboardBtn/index.tsx
+++ b/src/utils/CopyToClipboardBtn/index.tsx
@@ -26,14 +26,14 @@ const CopyToClipboardBtn = ({
 }: Props): React.ReactElement => {
   const [clicked, setClicked] = useState<boolean>(false);
 
-  const onButtonClick = (
-    event:
-      | React.MouseEvent<HTMLButtonElement>
-      | React.KeyboardEvent<HTMLButtonElement>
-  ): void => {
-    event.stopPropagation();
+  const copy = () => {
     copyTextToClipboard(textToCopy);
     setClicked(true);
+  };
+
+  const onButtonClick = (event: React.MouseEvent<HTMLButtonElement>): void => {
+    event.stopPropagation();
+    copy();
   };
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>): void => {
@@ -41,6 +41,7 @@ const CopyToClipboardBtn = ({
     if (event.keyCode === 13) {
       event.stopPropagation();
     }
+    copy();
   };
 
   const onButtonBlur = (): number =>


### PR DESCRIPTION
- [x] Remove type in EtherscanButton. It can be inferred using value length. If it's > 42 is assumed to be a TX else an address. If the value is > (66 a TX) can be assumed to be a data value, but for this case, EtherscaButton should not be used.

- [x] Rename AddressInfo to EthHashInfo and make the required changes to work with the new EthersacanButton interface. 

- [x] @fernandomg requested to stop events propagation for EtherscanButton and copyButton. That's to avoid problems with `<AddressInput />` component.