### PR TITLE
Storybook won't start without `file-loader` dependency installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "eslint-plugin-react": "7.20.5",
     "eslint-plugin-react-hooks": "4.0.8",
     "ethereum-blockies-base64": "^1.0.2",
+    "file-loader": "^6.0.0",
     "prettier": "2.0.5",
     "react": "16.13.1",
     "react-dom": "16.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5313,6 +5313,14 @@ file-loader@^4.2.0:
     loader-utils "^1.2.3"
     schema-utils "^2.5.0"
 
+file-loader@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.0.0.tgz#97bbfaab7a2460c07bcbd72d3a6922407f67649f"
+  integrity sha512-/aMOAYEFXDdjG0wytpTL5YQLfZnnTmLNjn+AIrJ/6HVnTfDqLsVKUUwkDf4I4kgex36BvjuXEn/TX9B/1ESyqQ==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^2.6.5"
+
 file-system-cache@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/file-system-cache/-/file-system-cache-1.0.5.tgz#84259b36a2bbb8d3d6eb1021d3132ffe64cfff4f"


### PR DESCRIPTION
Trying to run `yarn storybook` from a fresh `development` branch install fails:

![screenshot_2020-08-12_10-41-45](https://user-images.githubusercontent.com/43217/90048464-69fbe400-dc88-11ea-9174-5955faf4ac07.png)

After adding missing dependency it works