### PR TITLE
Added Tooltip component and stories

### DIFF
--- a/src/dataDisplay/Tooltip/index.tsx
+++ b/src/dataDisplay/Tooltip/index.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import MaterialUiTooltip, { TooltipProps } from '@material-ui/core/Tooltip';
+import { withStyles } from '@material-ui/core';
+
+import theme from '../../theme';
+
+export type Props = Omit<TooltipProps, 'arrow'>;
+
+const StyledToolTip = withStyles(() => ({
+  tooltip: {
+    backgroundColor: theme.colors.white,
+    color: theme.colors.text,
+    fontSize: theme.text.size.lg.fontSize,
+    lineHeight: theme.text.size.lg.lineHeight,
+    fontFamily: theme.fonts.fontFamily,
+    letterSpacing: 0,
+    textAlign: 'center',
+    maxWidth: '200px',
+    padding: '12px',
+    borderRadius: '8px',
+    boxShadow: '1px 2px 10px 0 rgba(40, 54, 61, 0.18)',
+  },
+  arrow: {
+    color: theme.colors.white,
+    width: '2em',
+  },
+  tooltipPlacementLeft: {
+    margin: '0 14px',
+  },
+  tooltipPlacementRight: {
+    margin: '0 14px',
+  },
+  tooltipPlacementTop: {
+    margin: '14px 0',
+  },
+  tooltipPlacementBottom: {
+    margin: '14px 0',
+  },
+}))(MaterialUiTooltip);
+
+export const Tooltip: React.FC<Props> = (props) => (
+  <StyledToolTip {...props} arrow />
+);

--- a/src/dataDisplay/Tooltip/tooltip.stories.tsx
+++ b/src/dataDisplay/Tooltip/tooltip.stories.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import { Tooltip } from '.';
+
+export default {
+  component: Tooltip,
+  title: 'Data Display/Tooltip',
+  parameters: {
+    componentSubtitle: 'Tooltip component.',
+  },
+};
+
+const hereSpam = <span style={{ borderBottom: '1px dashed black' }}>here</span>;
+
+export const Default = (): React.ReactElement => (
+  <div>
+    This text has a tooltip{' '}
+    <Tooltip title="I am a tooltip!">{hereSpam}</Tooltip>
+  </div>
+);
+
+export const MultiLineTooltip = (): React.ReactElement => (
+  <div>
+    This text has a tooltip{' '}
+    <Tooltip title="Each bracket consists of a single Ethereum address that places a buy-low and a sell-high order. Everytime the price goes through a bracket and activates both orders, the CMM provider earns the spread">
+      {hereSpam}
+    </Tooltip>
+  </div>
+);
+
+export const Interactive = (): React.ReactElement => (
+  <div>
+    This text has a tooltip{' '}
+    <Tooltip
+      title={
+        <span>
+          Contains a <a href="#">link</a>
+        </span>
+      }
+      interactive>
+      {hereSpam}
+    </Tooltip>
+  </div>
+);


### PR DESCRIPTION
# Description

New Tooltip component following the new design.

![screenshot_2020-08-21_11-04-49](https://user-images.githubusercontent.com/43217/90921071-4f1f2300-e39e-11ea-86ac-c8021159e526.png)

## Notes:
Could not make the props load on the storybook for this component. What am I missing?
![screenshot_2020-08-21_11-08-32](https://user-images.githubusercontent.com/43217/90921226-a6bd8e80-e39e-11ea-94d0-db2ad1c327ef.png)


