### PR TITLE
(Fix) `TextField` background-color

### DIFF
--- a/src/inputs/TextField/index.tsx
+++ b/src/inputs/TextField/index.tsx
@@ -26,6 +26,10 @@ const CustomTextField = styled((props: TextFieldProps) => (
       cursor: ${({ readOnly }) => (readOnly === true ? 'not-allowed' : 'auto')};
     }
 
+    .MuiFilledInput-root {
+      background-color: ${({ theme }) => theme.colors.inputField};
+    }
+
     .MuiFormLabel-root.Mui-focused {
       color: ${({ theme, error }) =>
         error ? theme.colors.error : theme.colors.primary};


### PR DESCRIPTION
This PR aims to fix the background color defined for the input fields, according to the specs.

