### PR TITLE
Text field input props

### DIFF
--- a/src/inputs/TextField/index.tsx
+++ b/src/inputs/TextField/index.tsx
@@ -78,7 +78,7 @@ function TextField({
       <CustomTextField
         {...rest}
         {...customProps}
-        {...inputRest}
+        inputProps={inputRest}
         className={className}
         size={undefined}
         name={name}

--- a/src/inputs/TextField/textField.stories.tsx
+++ b/src/inputs/TextField/textField.stories.tsx
@@ -27,6 +27,21 @@ export const SimpleTextField = (): React.ReactElement => {
   );
 };
 
+export const SimpleNumberField = (): React.ReactElement => {
+  const [value, setValue] = useState<string>('');
+  return (
+    <form noValidate autoComplete="off" onSubmit={onSubmit}>
+      <TextField
+        id="standard-name"
+        label="Name"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        input={{ type: 'number', min: 5, max: 10, step: 1 }}
+      />
+    </form>
+  );
+};
+
 export const Error = (): React.ReactElement => {
   const [value, setValue] = useState<string>('some incorrect value');
   return (


### PR DESCRIPTION
On `<TextField>` component, now `inputProps` are passed down to MUI component.

MUI reference https://material-ui.com/api/text-field/
![screenshot_2020-12-11_11-00-22](https://user-images.githubusercontent.com/43217/101944161-1f8c6480-3ba1-11eb-9b58-11309e03b78e.png)

With this change, `<TextField>` `input` props now can contain HTML props and properly pass it down to inner `<input>` element.

Added a Story for testing it with a `number` input with `min` and `max` set
![screenshot_2020-12-11_11-07-13](https://user-images.githubusercontent.com/43217/101944273-4b0f4f00-3ba1-11eb-806f-a3275b4e16c7.png)
