### PR TITLE
Fix - Add button role

### DIFF
--- a/src/utils/CopyToClipboardBtn/index.tsx
+++ b/src/utils/CopyToClipboardBtn/index.tsx
@@ -50,6 +50,7 @@ const CopyToClipboardBtn = ({
   return (
     <StyledButton
       className={className}
+      type="button"
       onClick={onButtonClick}
       onKeyDown={onKeyDown}
       onMouseLeave={onButtonBlur}>


### PR DESCRIPTION
This helps to fix https://app.zenhub.com/workspaces/safe-multisig---web-5ce554debb310a35b2f8b6f8/issues/gnosis/safe-react/1976 since button as default is `submit` type