### PR TITLE
feature: Add margin and side props to IconText 

### DIFF
--- a/src/dataDisplay/Icon/index.tsx
+++ b/src/dataDisplay/Icon/index.tsx
@@ -76,11 +76,10 @@ import unlocked from './images/unlocked';
 import userEdit from './images/userEdit';
 import wallet from './images/wallet';
 
-import { ThemeColors, ThemeIconSize, ThemeMargin } from '../../theme';
+import { ThemeColors, ThemeIconSize } from '../../theme';
 
-const StyledIcon = styled.span<{ color?: ThemeColors; margin?: ThemeMargin }>`
+const StyledIcon = styled.span<{ color?: ThemeColors }>`
   display: inline-flex;
-  margin: 0 ${({ theme }) => theme.margin.xs}; /* TODO review this */
 
   .icon-color {
     fill: ${({ theme, color }) =>
@@ -169,7 +168,6 @@ export type IconTypes = keyof IconType;
 export type Props = {
   type: IconTypes;
   size: ThemeIconSize;
-  margin?: ThemeMargin;
   color?: ThemeColors;
   tooltip?: string;
   className?: string;
@@ -182,13 +180,12 @@ export type Props = {
 export const Icon = ({
   type,
   size,
-  margin,
   color,
   tooltip,
   className,
 }: Props): React.ReactElement => {
   const IconElement = (
-    <StyledIcon color={color} margin={margin} className={className}>
+    <StyledIcon color={color} className={className}>
       {icons[type][size]}
     </StyledIcon>
   );

--- a/src/dataDisplay/Icon/index.tsx
+++ b/src/dataDisplay/Icon/index.tsx
@@ -76,10 +76,11 @@ import unlocked from './images/unlocked';
 import userEdit from './images/userEdit';
 import wallet from './images/wallet';
 
-import { ThemeColors, ThemeIconSize } from '../../theme';
+import { ThemeColors, ThemeIconSize, ThemeMargin } from '../../theme';
 
-const StyledIcon = styled.span<{ color?: ThemeColors }>`
+const StyledIcon = styled.span<{ color?: ThemeColors; margin?: ThemeMargin }>`
   display: inline-flex;
+  margin: 0 ${({ theme }) => theme.margin.xs}; /* TODO review this */
 
   .icon-color {
     fill: ${({ theme, color }) =>
@@ -168,6 +169,7 @@ export type IconTypes = keyof IconType;
 export type Props = {
   type: IconTypes;
   size: ThemeIconSize;
+  margin?: ThemeMargin;
   color?: ThemeColors;
   tooltip?: string;
   className?: string;
@@ -180,12 +182,13 @@ export type Props = {
 export const Icon = ({
   type,
   size,
+  margin,
   color,
   tooltip,
   className,
 }: Props): React.ReactElement => {
   const IconElement = (
-    <StyledIcon color={color} className={className}>
+    <StyledIcon color={color} margin={margin} className={className}>
       {icons[type][size]}
     </StyledIcon>
   );

--- a/src/dataDisplay/IconText/index.stories.tsx
+++ b/src/dataDisplay/IconText/index.stories.tsx
@@ -21,3 +21,39 @@ export const Sizes = (): React.ReactElement => {
     </>
   );
 };
+
+export const IconPosition = (): React.ReactElement => {
+  return (
+    <>
+      <IconText
+        iconSize="sm"
+        textSize="sm"
+        iconType="add"
+        text="Some text"
+        icon="right"
+      />
+      <IconText
+        iconSize="sm"
+        textSize="xl"
+        iconType="add"
+        text="Some text"
+        icon="right"
+      />
+
+      <IconText
+        iconSize="md"
+        textSize="sm"
+        iconType="add"
+        text="Some text"
+        icon="right"
+      />
+      <IconText
+        iconSize="md"
+        textSize="xl"
+        iconType="add"
+        text="Some text"
+        icon="right"
+      />
+    </>
+  );
+};

--- a/src/dataDisplay/IconText/index.stories.tsx
+++ b/src/dataDisplay/IconText/index.stories.tsx
@@ -13,11 +13,35 @@ export default {
 export const Sizes = (): React.ReactElement => {
   return (
     <>
-      <IconText iconSize="sm" textSize="sm" iconType="add" text="Some text" />
-      <IconText iconSize="sm" textSize="xl" iconType="add" text="Some text" />
+      <IconText
+        iconSize="sm"
+        margin="md"
+        textSize="sm"
+        iconType="add"
+        text="Some text"
+      />
+      <IconText
+        iconSize="sm"
+        margin="md"
+        textSize="xl"
+        iconType="add"
+        text="Some text"
+      />
 
-      <IconText iconSize="md" textSize="sm" iconType="add" text="Some text" />
-      <IconText iconSize="md" textSize="xl" iconType="add" text="Some text" />
+      <IconText
+        iconSize="md"
+        margin="md"
+        textSize="sm"
+        iconType="add"
+        text="Some text"
+      />
+      <IconText
+        iconSize="md"
+        margin="xxl"
+        textSize="xl"
+        iconType="add"
+        text="Some text"
+      />
     </>
   );
 };
@@ -27,6 +51,7 @@ export const IconPosition = (): React.ReactElement => {
     <>
       <IconText
         iconSize="sm"
+        margin="md"
         textSize="sm"
         iconType="add"
         text="Some text"
@@ -34,6 +59,7 @@ export const IconPosition = (): React.ReactElement => {
       />
       <IconText
         iconSize="sm"
+        margin="md"
         textSize="xl"
         iconType="add"
         text="Some text"
@@ -42,6 +68,7 @@ export const IconPosition = (): React.ReactElement => {
 
       <IconText
         iconSize="md"
+        margin="md"
         textSize="sm"
         iconType="add"
         text="Some text"
@@ -49,6 +76,7 @@ export const IconPosition = (): React.ReactElement => {
       />
       <IconText
         iconSize="md"
+        margin="md"
         textSize="xl"
         iconType="add"
         text="Some text"

--- a/src/dataDisplay/IconText/index.stories.tsx
+++ b/src/dataDisplay/IconText/index.stories.tsx
@@ -30,14 +30,14 @@ export const IconPosition = (): React.ReactElement => {
         textSize="sm"
         iconType="add"
         text="Some text"
-        icon="right"
+        iconSide="right"
       />
       <IconText
         iconSize="sm"
         textSize="xl"
         iconType="add"
         text="Some text"
-        icon="right"
+        iconSide="right"
       />
 
       <IconText
@@ -45,14 +45,14 @@ export const IconPosition = (): React.ReactElement => {
         textSize="sm"
         iconType="add"
         text="Some text"
-        icon="right"
+        iconSide="right"
       />
       <IconText
         iconSize="md"
         textSize="xl"
         iconType="add"
         text="Some text"
-        icon="right"
+        iconSide="right"
       />
     </>
   );

--- a/src/dataDisplay/IconText/index.stories.tsx
+++ b/src/dataDisplay/IconText/index.stories.tsx
@@ -15,14 +15,14 @@ export const Sizes = (): React.ReactElement => {
     <>
       <IconText
         iconSize="sm"
-        margin="md"
+        margin="xs"
         textSize="sm"
         iconType="add"
         text="Some text"
       />
       <IconText
         iconSize="sm"
-        margin="md"
+        margin="xs"
         textSize="xl"
         iconType="add"
         text="Some text"
@@ -30,14 +30,14 @@ export const Sizes = (): React.ReactElement => {
 
       <IconText
         iconSize="md"
-        margin="md"
+        margin="xs"
         textSize="sm"
         iconType="add"
         text="Some text"
       />
       <IconText
         iconSize="md"
-        margin="xxl"
+        margin="xs"
         textSize="xl"
         iconType="add"
         text="Some text"
@@ -51,7 +51,7 @@ export const IconPosition = (): React.ReactElement => {
     <>
       <IconText
         iconSize="sm"
-        margin="md"
+        margin="xs"
         textSize="sm"
         iconType="add"
         text="Some text"
@@ -59,7 +59,7 @@ export const IconPosition = (): React.ReactElement => {
       />
       <IconText
         iconSize="sm"
-        margin="md"
+        margin="xs"
         textSize="xl"
         iconType="add"
         text="Some text"
@@ -68,11 +68,34 @@ export const IconPosition = (): React.ReactElement => {
 
       <IconText
         iconSize="md"
-        margin="md"
+        margin="xs"
         textSize="sm"
         iconType="add"
         text="Some text"
         iconSide="right"
+      />
+      <IconText
+        iconSize="md"
+        margin="xs"
+        textSize="xl"
+        iconType="add"
+        text="Some text"
+        iconSide="right"
+      />
+    </>
+  );
+};
+
+export const IconMargin = (): React.ReactElement => {
+  return (
+    <>
+      <IconText
+        iconSize="md"
+        margin="md"
+        textSize="md"
+        iconType="add"
+        text="Some text"
+        iconSide="left"
       />
       <IconText
         iconSize="md"

--- a/src/dataDisplay/IconText/index.tsx
+++ b/src/dataDisplay/IconText/index.tsx
@@ -21,11 +21,19 @@ type Props = {
   iconSide?: 'left' | 'right';
 };
 
-const StyledIconText = styled.div<{ margin: ThemeMargin }>`
+const LeftIconText = styled.div<{ margin: ThemeMargin }>`
   display: flex;
   align-items: center;
   svg {
-    margin: 0 ${({ theme, margin }) => theme.margin[margin]};
+    margin: 0 ${({ theme, margin }) => theme.margin[margin]} 0 0;
+  }
+`;
+
+const RightIconText = styled.div<{ margin: ThemeMargin }>`
+  display: flex;
+  align-items: center;
+  svg {
+    margin: 0 0 0 ${({ theme, margin }) => theme.margin[margin]};
   }
 `;
 
@@ -43,19 +51,19 @@ const IconText = ({
   className,
 }: Props): React.ReactElement => {
   return iconSide === 'right' ? (
-    <StyledIconText className={className} margin={margin}>
+    <RightIconText className={className} margin={margin}>
       <Text size={textSize} color={color}>
         {text}
       </Text>
       <Icon size={iconSize} type={iconType} color={color} />
-    </StyledIconText>
+    </RightIconText>
   ) : (
-    <StyledIconText className={className} margin={margin}>
+    <LeftIconText className={className} margin={margin}>
       <Icon size={iconSize} type={iconType} color={color} />
       <Text size={textSize} color={color}>
         {text}
       </Text>
-    </StyledIconText>
+    </LeftIconText>
   );
 };
 

--- a/src/dataDisplay/IconText/index.tsx
+++ b/src/dataDisplay/IconText/index.tsx
@@ -13,7 +13,7 @@ import Text from '../Text';
 type Props = {
   iconType: keyof IconType;
   iconSize: ThemeIconSize;
-  margin: ThemeMargin;
+  margin?: ThemeMargin;
   textSize: ThemeTextSize;
   color?: ThemeColors;
   text: string;

--- a/src/dataDisplay/IconText/index.tsx
+++ b/src/dataDisplay/IconText/index.tsx
@@ -1,13 +1,19 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { ThemeColors, ThemeIconSize, ThemeTextSize } from '../../theme';
+import {
+  ThemeColors,
+  ThemeIconSize,
+  ThemeMargin,
+  ThemeTextSize,
+} from '../../theme';
 import { Icon, IconType } from '../Icon';
 import Text from '../Text';
 
 type Props = {
   iconType: keyof IconType;
   iconSize: ThemeIconSize;
+  margin: ThemeMargin;
   textSize: ThemeTextSize;
   color?: ThemeColors;
   text: string;
@@ -19,9 +25,9 @@ const StyledIconText = styled.div`
   display: flex;
   align-items: center;
 
-  p {
+  /* p {
     margin-left: 6px;
-  }
+  } */
 `;
 
 /**
@@ -29,6 +35,7 @@ const StyledIconText = styled.div`
  */
 const IconText = ({
   iconSize,
+  margin = 'md',
   textSize,
   iconType,
   text,
@@ -41,11 +48,11 @@ const IconText = ({
       <Text size={textSize} color={color}>
         {text}
       </Text>
-      <Icon size={iconSize} type={iconType} color={color} />
+      <Icon size={iconSize} margin={margin} type={iconType} color={color} />
     </StyledIconText>
   ) : (
     <StyledIconText className={className}>
-      <Icon size={iconSize} type={iconType} color={color} />
+      <Icon size={iconSize} margin={margin} type={iconType} color={color} />
       <Text size={textSize} color={color}>
         {text}
       </Text>

--- a/src/dataDisplay/IconText/index.tsx
+++ b/src/dataDisplay/IconText/index.tsx
@@ -25,12 +25,8 @@ const StyledIconText = styled.div<{ margin: ThemeMargin }>`
   display: flex;
   align-items: center;
   svg {
-    margin: 0 ${({ theme }) => theme.margin.xs};
+    margin: 0 ${({ theme, margin }) => theme.margin[margin]};
   }
-`;
-
-const StyledIcon = styled(Icon)`
-  /* margin: 20px; */
 `;
 
 /**
@@ -38,7 +34,7 @@ const StyledIcon = styled(Icon)`
  */
 const IconText = ({
   iconSize,
-  margin = 'md',
+  margin = 'xs',
   textSize,
   iconType,
   text,
@@ -51,11 +47,11 @@ const IconText = ({
       <Text size={textSize} color={color}>
         {text}
       </Text>
-      <StyledIcon size={iconSize} type={iconType} color={color} />
+      <Icon size={iconSize} type={iconType} color={color} />
     </StyledIconText>
   ) : (
     <StyledIconText className={className} margin={margin}>
-      <StyledIcon size={iconSize} type={iconType} color={color} />
+      <Icon size={iconSize} type={iconType} color={color} />
       <Text size={textSize} color={color}>
         {text}
       </Text>

--- a/src/dataDisplay/IconText/index.tsx
+++ b/src/dataDisplay/IconText/index.tsx
@@ -12,6 +12,7 @@ type Props = {
   color?: ThemeColors;
   text: string;
   className?: string;
+  icon?: 'left' | 'right';
 };
 
 const StyledIconText = styled.div`
@@ -31,15 +32,25 @@ const IconText = ({
   textSize,
   iconType,
   text,
+  icon = 'left',
   color,
   className,
-}: Props): React.ReactElement => (
-  <StyledIconText className={className}>
-    <Icon size={iconSize} type={iconType} color={color} />
-    <Text size={textSize} color={color}>
-      {text}
-    </Text>
-  </StyledIconText>
-);
+}: Props): React.ReactElement => {
+  return icon === 'right' ? (
+    <StyledIconText className={className}>
+      <Text size={textSize} color={color}>
+        {text}
+      </Text>
+      <Icon size={iconSize} type={iconType} color={color} />
+    </StyledIconText>
+  ) : (
+    <StyledIconText className={className}>
+      <Icon size={iconSize} type={iconType} color={color} />
+      <Text size={textSize} color={color}>
+        {text}
+      </Text>
+    </StyledIconText>
+  );
+};
 
 export default IconText;

--- a/src/dataDisplay/IconText/index.tsx
+++ b/src/dataDisplay/IconText/index.tsx
@@ -21,13 +21,16 @@ type Props = {
   iconSide?: 'left' | 'right';
 };
 
-const StyledIconText = styled.div`
+const StyledIconText = styled.div<{ margin: ThemeMargin }>`
   display: flex;
   align-items: center;
+  svg {
+    margin: 0 ${({ theme }) => theme.margin.xs};
+  }
+`;
 
-  /* p {
-    margin-left: 6px;
-  } */
+const StyledIcon = styled(Icon)`
+  /* margin: 20px; */
 `;
 
 /**
@@ -44,15 +47,15 @@ const IconText = ({
   className,
 }: Props): React.ReactElement => {
   return iconSide === 'right' ? (
-    <StyledIconText className={className}>
+    <StyledIconText className={className} margin={margin}>
       <Text size={textSize} color={color}>
         {text}
       </Text>
-      <Icon size={iconSize} margin={margin} type={iconType} color={color} />
+      <StyledIcon size={iconSize} type={iconType} color={color} />
     </StyledIconText>
   ) : (
-    <StyledIconText className={className}>
-      <Icon size={iconSize} margin={margin} type={iconType} color={color} />
+    <StyledIconText className={className} margin={margin}>
+      <StyledIcon size={iconSize} type={iconType} color={color} />
       <Text size={textSize} color={color}>
         {text}
       </Text>

--- a/src/dataDisplay/IconText/index.tsx
+++ b/src/dataDisplay/IconText/index.tsx
@@ -12,7 +12,7 @@ type Props = {
   color?: ThemeColors;
   text: string;
   className?: string;
-  icon?: 'left' | 'right';
+  iconSide?: 'left' | 'right';
 };
 
 const StyledIconText = styled.div`
@@ -32,11 +32,11 @@ const IconText = ({
   textSize,
   iconType,
   text,
-  icon = 'left',
+  iconSide = 'left',
   color,
   className,
 }: Props): React.ReactElement => {
-  return icon === 'right' ? (
+  return iconSide === 'right' ? (
     <StyledIconText className={className}>
       <Text size={textSize} color={color}>
         {text}

--- a/src/navigation/Tab/index.tsx
+++ b/src/navigation/Tab/index.tsx
@@ -115,6 +115,7 @@ const Tab = ({
       return (
         <IconText
           iconSize="sm"
+          margin="md"
           iconType={item.icon}
           textSize="sm"
           color={selectedTab === item.id ? 'primary' : 'text'}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -54,6 +54,14 @@ const theme = {
     fontFamily: `'Averta', 'Roboto', 'Helvetica Neue', 'Arial', 'Segoe UI', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', '-apple-system', 'BlinkMacSystemFont', sans-serif`,
     fontFamilyCode: `source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace`,
   },
+  margin: {
+    xs: '4px',
+    sm: '8px',
+    md: '12px',
+    lg: '16px',
+    xl: '20px',
+    xxl: '24px',
+  },
   icons: {
     size: {
       sm: '16',
@@ -142,6 +150,7 @@ export type ThemeButtonSize = keyof Theme['buttons']['size'];
 export type ThemeColors = keyof Theme['colors'];
 export type ThemeIdenticonSize = keyof Theme['identicon']['size'];
 export type ThemeIconSize = keyof Theme['icons']['size'];
+export type ThemeMargin = keyof Theme['margin'];
 export type ThemeLoaderSize = keyof Theme['loader']['size'];
 export type ThemeStatusDotSize = keyof Theme['statusDot']['size'];
 export type ThemeTextSize = keyof Theme['text']['size'];

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -55,7 +55,8 @@ const theme = {
     fontFamilyCode: `source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace`,
   },
   margin: {
-    xs: '4px',
+    xxs: '4px',
+    xs: '6px',
     sm: '8px',
     md: '12px',
     lg: '16px',


### PR DESCRIPTION
Related to #109.

### Motivation ###
Every time we are using an icon + label in SR (safe-react) or SRC (safe-react-components) we need to add a css wrapper in order to align the text and the icon.
This component intends to fix that problem.

### What's new ###
Its adds two new properties to `IconText`, side (left or right) and margin.
* side: used to indicate at what side the icon will be rendered. In SR, we use both icon + text for simple labels and text + icon for links. 
* margin: add some space between the icon and text.

### How to test it ###
As this repo only provides components and as we making use of [storybook](https://storybook.js.org/), it would be enough to have a story that represents all the variants for each component. In the PR description, you will find a link to a deployed instance of `storybook`. For this particular PR the link is https://pr113--safereactcomponents.review.gnosisdev.com.

cc: @katspaugh