### PR TITLE
feature: EthHashInfo add customAvatar fallback

### DIFF
--- a/src/ethereum/EthHashInfo/ethHashInfo.stories.tsx
+++ b/src/ethereum/EthHashInfo/ethHashInfo.stories.tsx
@@ -38,6 +38,25 @@ export const WithCustomAvatar = (): React.ReactElement => (
   />
 );
 
+export const WithCustomAvatarFallback = (): React.ReactElement => (
+  <EthHashInfo
+    hash={hash}
+    showAvatar
+    customAvatar="https://no-file.png"
+    customAvatarFallback="https://gnosis-safe-token-logos.s3.amazonaws.com/0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa.png"
+    shortenHash={4}
+  />
+);
+
+export const WithCustomAvatarFallbackIdenticon = (): React.ReactElement => (
+  <EthHashInfo
+    hash={hash}
+    showAvatar
+    customAvatar="https://no-file.png"
+    shortenHash={4}
+  />
+);
+
 export const WithButtons = (): React.ReactElement => (
   <EthHashInfo
     hash={hash}

--- a/src/ethereum/EthHashInfo/ethHashInfo.stories.tsx
+++ b/src/ethereum/EthHashInfo/ethHashInfo.stories.tsx
@@ -42,8 +42,8 @@ export const WithCustomAvatarFallback = (): React.ReactElement => (
   <EthHashInfo
     hash={hash}
     showAvatar
-    customAvatar="https://no-file.png"
-    customAvatarFallback="https://gnosis-safe-token-logos.s3.amazonaws.com/0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa.png"
+    customAvatar="https://broken.png"
+    customAvatarFallback="https://gnosis-safe-token-logos.s3.amazonaws.com/0x6810e776880C02933D47DB1b9fc05908e5386b96.png"
     shortenHash={4}
   />
 );

--- a/src/ethereum/EthHashInfo/index.tsx
+++ b/src/ethereum/EthHashInfo/index.tsx
@@ -13,8 +13,6 @@ import { textShortener } from '../../utils/strings';
 import { ThemeTextSize, ThemeColors, ThemeIdenticonSize } from '../../theme';
 import { ExplorerInfo } from '../../typings/misc';
 
-import asd from 'src/utils/modals/ManageListModal/appsIcon.svg';
-
 const StyledContainer = styled.div`
   display: flex;
   align-items: center;
@@ -56,17 +54,11 @@ type Props = {
   textSize?: ThemeTextSize;
   showAvatar?: boolean;
   customAvatar?: string;
+  customAvatarFallback?: string;
   avatarSize?: ThemeIdenticonSize;
   showCopyBtn?: boolean;
   menuItems?: EllipsisMenuItem[];
   explorerUrl?: ExplorerInfo;
-};
-
-export const setAppImageFallback = (
-  error: SyntheticEvent<HTMLImageElement, Event>
-): void => {
-  error.currentTarget.onerror = null;
-  error.currentTarget.src = asd;
 };
 
 const EthHashInfo = ({
@@ -79,42 +71,56 @@ const EthHashInfo = ({
   shortenHash,
   showAvatar,
   customAvatar,
+  customAvatarFallback,
   avatarSize = 'md',
   showCopyBtn,
   menuItems,
   explorerUrl,
-}: Props): React.ReactElement => (
-  <StyledContainer className={className}>
-    {showAvatar && (
-      <AvatarContainer>
-        {customAvatar ? (
-          <StyledImg src={customAvatar} size={avatarSize} onerror={onerror} />
-        ) : (
-          <Identicon address={hash} size={avatarSize} />
-        )}
-      </AvatarContainer>
-    )}
+}: Props): React.ReactElement => {
+  const setAppImageFallback = (
+    error: SyntheticEvent<HTMLImageElement, Event>
+  ): void => {
+    error.currentTarget.onerror = null;
+    error.currentTarget.src = customAvatarFallback || '';
+  };
 
-    <InfoContainer>
-      {name && (
-        <Text size={textSize} color={textColor}>
-          {name}
-        </Text>
+  return (
+    <StyledContainer className={className}>
+      {showAvatar && (
+        <AvatarContainer>
+          {customAvatar ? (
+            <StyledImg
+              src={customAvatar}
+              size={avatarSize}
+              onError={setAppImageFallback}
+            />
+          ) : (
+            <Identicon address={hash} size={avatarSize} />
+          )}
+        </AvatarContainer>
       )}
-      <AddressContainer>
-        {showHash && (
+
+      <InfoContainer>
+        {name && (
           <Text size={textSize} color={textColor}>
-            {shortenHash
-              ? textShortener(hash, shortenHash + 2, shortenHash)
-              : hash}
+            {name}
           </Text>
         )}
-        {showCopyBtn && <CopyToClipboardBtn textToCopy={hash} />}
-        {explorerUrl && <ExplorerButton explorerUrl={explorerUrl} />}
-        {menuItems && <EllipsisMenu menuItems={menuItems} />}
-      </AddressContainer>
-    </InfoContainer>
-  </StyledContainer>
-);
+        <AddressContainer>
+          {showHash && (
+            <Text size={textSize} color={textColor}>
+              {shortenHash
+                ? textShortener(hash, shortenHash + 2, shortenHash)
+                : hash}
+            </Text>
+          )}
+          {showCopyBtn && <CopyToClipboardBtn textToCopy={hash} />}
+          {explorerUrl && <ExplorerButton explorerUrl={explorerUrl} />}
+          {menuItems && <EllipsisMenu menuItems={menuItems} />}
+        </AddressContainer>
+      </InfoContainer>
+    </StyledContainer>
+  );
+};
 
 export default EthHashInfo;

--- a/src/ethereum/EthHashInfo/index.tsx
+++ b/src/ethereum/EthHashInfo/index.tsx
@@ -1,4 +1,4 @@
-import React, { SyntheticEvent } from 'react';
+import React, { useState, SyntheticEvent } from 'react';
 import styled from 'styled-components';
 
 import {
@@ -77,18 +77,24 @@ const EthHashInfo = ({
   menuItems,
   explorerUrl,
 }: Props): React.ReactElement => {
+  const [fallbackToIdenticon, setFallbackToIdenticon] = useState(false);
+
   const setAppImageFallback = (
     error: SyntheticEvent<HTMLImageElement, Event>
   ): void => {
-    error.currentTarget.onerror = null;
-    error.currentTarget.src = customAvatarFallback || '';
+    if (customAvatarFallback && !fallbackToIdenticon) {
+      error.currentTarget.onerror = null;
+      error.currentTarget.src = customAvatarFallback;
+    } else {
+      setFallbackToIdenticon(true);
+    }
   };
 
   return (
     <StyledContainer className={className}>
       {showAvatar && (
         <AvatarContainer>
-          {customAvatar ? (
+          {!fallbackToIdenticon && customAvatar ? (
             <StyledImg
               src={customAvatar}
               size={avatarSize}

--- a/src/ethereum/EthHashInfo/index.tsx
+++ b/src/ethereum/EthHashInfo/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { SyntheticEvent } from 'react';
 import styled from 'styled-components';
 
 import {
@@ -12,6 +12,8 @@ import {
 import { textShortener } from '../../utils/strings';
 import { ThemeTextSize, ThemeColors, ThemeIdenticonSize } from '../../theme';
 import { ExplorerInfo } from '../../typings/misc';
+
+import asd from 'src/utils/modals/ManageListModal/appsIcon.svg';
 
 const StyledContainer = styled.div`
   display: flex;
@@ -60,6 +62,13 @@ type Props = {
   explorerUrl?: ExplorerInfo;
 };
 
+export const setAppImageFallback = (
+  error: SyntheticEvent<HTMLImageElement, Event>
+): void => {
+  error.currentTarget.onerror = null;
+  error.currentTarget.src = asd;
+};
+
 const EthHashInfo = ({
   hash,
   showHash = true,
@@ -79,7 +88,7 @@ const EthHashInfo = ({
     {showAvatar && (
       <AvatarContainer>
         {customAvatar ? (
-          <StyledImg src={customAvatar} size={avatarSize} />
+          <StyledImg src={customAvatar} size={avatarSize} onerror={onerror} />
         ) : (
           <Identicon address={hash} size={avatarSize} />
         )}

--- a/src/ethereum/EthHashInfo/index.tsx
+++ b/src/ethereum/EthHashInfo/index.tsx
@@ -78,13 +78,13 @@ const EthHashInfo = ({
   explorerUrl,
 }: Props): React.ReactElement => {
   const [fallbackToIdenticon, setFallbackToIdenticon] = useState(false);
+  const [fallbackSrc, setFallabckSrc] = useState<undefined | string>(undefined);
 
   const setAppImageFallback = (
     error: SyntheticEvent<HTMLImageElement, Event>
   ): void => {
     if (customAvatarFallback && !fallbackToIdenticon) {
-      error.currentTarget.onerror = null;
-      error.currentTarget.src = customAvatarFallback;
+      setFallabckSrc(customAvatarFallback);
     } else {
       setFallbackToIdenticon(true);
     }
@@ -96,7 +96,7 @@ const EthHashInfo = ({
         <AvatarContainer>
           {!fallbackToIdenticon && customAvatar ? (
             <StyledImg
-              src={customAvatar}
+              src={fallbackSrc || customAvatar}
               size={avatarSize}
               onError={setAppImageFallback}
             />

--- a/tests/__snapshots__/storybook.test.js.snap
+++ b/tests/__snapshots__/storybook.test.js.snap
@@ -5926,8 +5926,73 @@ exports[`Storyshots Ethereum/Eth hash Info With Custom Avatar 1`] = `
   >
     <img
       className="sc-bBrOnJ jPNRUi"
+      onError={[Function]}
       size="md"
       src="https://gnosis-safe-token-logos.s3.amazonaws.com/0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa.png"
+    />
+  </div>
+  <div
+    className="sc-jNMdTA gJUNtj"
+  >
+    <div
+      className="sc-dOSReg cTzfaq"
+    >
+      <p
+        className="sc-crrsfI fiKdgY"
+        color="text"
+        size="lg"
+      >
+        0x6990...ba4f
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Ethereum/Eth hash Info With Custom Avatar Fallback 1`] = `
+<div
+  className="sc-eggNIi bGtkep"
+>
+  <div
+    className="sc-cTkwdZ kJbbRd"
+  >
+    <img
+      className="sc-bBrOnJ jPNRUi"
+      onError={[Function]}
+      size="md"
+      src="https://no-file.png"
+    />
+  </div>
+  <div
+    className="sc-jNMdTA gJUNtj"
+  >
+    <div
+      className="sc-dOSReg cTzfaq"
+    >
+      <p
+        className="sc-crrsfI fiKdgY"
+        color="text"
+        size="lg"
+      >
+        0x6990...ba4f
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Ethereum/Eth hash Info With Custom Avatar Fallback Identicon 1`] = `
+<div
+  className="sc-eggNIi bGtkep"
+>
+  <div
+    className="sc-cTkwdZ kJbbRd"
+  >
+    <img
+      className="sc-bBrOnJ jPNRUi"
+      onError={[Function]}
+      size="md"
+      src="https://no-file.png"
     />
   </div>
   <div

--- a/tests/__snapshots__/storybook.test.js.snap
+++ b/tests/__snapshots__/storybook.test.js.snap
@@ -5960,7 +5960,7 @@ exports[`Storyshots Ethereum/Eth hash Info With Custom Avatar Fallback 1`] = `
       className="sc-bBrOnJ jPNRUi"
       onError={[Function]}
       size="md"
-      src="https://no-file.png"
+      src="https://broken.png"
     />
   </div>
   <div


### PR DESCRIPTION
We need to handle the case for when `customAvatar` is broken.

- I added a new property called `customAvatarFallaback` that receives an URL to callback in case the main image is broken
- I no `customAvatarFallaback` was provided it fallback to Identicon.

These changes are needed for https://app.zenhub.com/workspaces/safe-multisig---web-5ce554debb310a35b2f8b6f8/issues/gnosis/safe-react/2133