### PR TITLE
Feature - Checkbox label supports passing a node

### DIFF
--- a/src/inputs/Checkbox/index.tsx
+++ b/src/inputs/Checkbox/index.tsx
@@ -9,7 +9,7 @@ import styled from 'styled-components';
 import theme from '../../theme';
 
 export interface Props {
-  label: React.ReactNode | string;
+  label: React.ReactNode;
   checked: boolean;
   name: string;
   onChange: (

--- a/src/inputs/Checkbox/index.tsx
+++ b/src/inputs/Checkbox/index.tsx
@@ -9,7 +9,7 @@ import styled from 'styled-components';
 import theme from '../../theme';
 
 export interface Props {
-  label: string;
+  label: React.ReactNode | string;
   checked: boolean;
   name: string;
   onChange: (


### PR DESCRIPTION
Since MaterialUI supports passing a `node` as `label`, we consider it important to add support for the checkbox component to receive a node for `label` prop