### PR TITLE
Downscale the collectibles icon

### DIFF
--- a/src/dataDisplay/Icon/images/collectibles.tsx
+++ b/src/dataDisplay/Icon/images/collectibles.tsx
@@ -27,7 +27,7 @@ export default {
       xmlns="http://www.w3.org/2000/svg"
       width="24"
       height="24"
-      viewBox="0 0 24 24">
+      viewBox="-3 -3 30 30">
       <defs>
         <path id="prefix__a" d="M0 0L23.984 0 23.984 22.002 0 22.002z" />
       </defs>

--- a/tests/__snapshots__/storybook.test.js.snap
+++ b/tests/__snapshots__/storybook.test.js.snap
@@ -3264,7 +3264,7 @@ exports[`Storyshots Data Display/Icon Icons 1`] = `
     >
       <svg
         height="24"
-        viewBox="0 0 24 24"
+        viewBox="-3 -3 30 30"
         width="24"
         xmlns="http://www.w3.org/2000/svg"
       >


### PR DESCRIPTION
The diamond icon is a bit too large compared to the other icons. I've made it a bit smaller so that it better fits in the sidebar menu.

Before | After
-------|------
<img width="897" alt="Screenshot 2021-08-03 at 12 32 13" src="https://user-images.githubusercontent.com/381895/128002137-7dba0b1a-de3f-4524-84ac-06dbb08e9dbb.png"> | <img width="788" alt="Screenshot 2021-08-03 at 12 31 55" src="https://user-images.githubusercontent.com/381895/128002169-8ea9ed31-f7fb-4495-b148-9886dc6b0563.png">

In the storybook:
<img width="491" alt="Screenshot 2021-08-03 at 12 35 59" src="https://user-images.githubusercontent.com/381895/128002327-ab62984f-2d50-4174-beea-cab18bf284a3.png">
