### PR TITLE
Add icon type selection to copy component

### DIFF
--- a/src/utils/CopyToClipboardBtn/index.stories.tsx
+++ b/src/utils/CopyToClipboardBtn/index.stories.tsx
@@ -13,3 +13,7 @@ export default {
 export const Copy = (): React.ReactElement => (
   <CopyToClipboardBtn textToCopy="some value" />
 );
+
+export const CopyWithDifferentLogo = (): React.ReactElement => (
+  <CopyToClipboardBtn textToCopy="some value" iconType="share" />
+);

--- a/src/utils/CopyToClipboardBtn/index.tsx
+++ b/src/utils/CopyToClipboardBtn/index.tsx
@@ -27,11 +27,16 @@ const StyledButton = styled.button`
 type Props = {
   textToCopy: string;
   className?: string;
+  iconType?: Parameters<typeof Icon>[0]['type'];
+  tooltip?: string;
+  tooltipAfterCopy?: string;
 };
 
 const CopyToClipboardBtn = ({
   className,
   textToCopy,
+  iconType = 'copy',
+  tooltip = 'Copy to clipboard',
 }: Props): React.ReactElement => {
   const [clicked, setClicked] = useState<boolean>(false);
 
@@ -67,8 +72,8 @@ const CopyToClipboardBtn = ({
       <Icon
         size="sm"
         color="icon"
-        type="copy"
-        tooltip={clicked ? 'Copied' : 'Copy to clipboard'}
+        type={iconType}
+        tooltip={clicked ? 'Copied' : tooltip}
       />
     </StyledButton>
   );

--- a/tests/utils/CopyToClipboardBtn/__snapshots__/index.stories.storyshot
+++ b/tests/utils/CopyToClipboardBtn/__snapshots__/index.stories.storyshot
@@ -43,3 +43,46 @@ exports[`Storyshots Utils/CopyToClipboardBtn Copy 1`] = `
   </span>
 </button>
 `;
+
+exports[`Storyshots Utils/CopyToClipboardBtn Copy With Different Logo 1`] = `
+<button
+  className="sc-laZMeE GhNCJ"
+  onClick={[Function]}
+  onKeyDown={[Function]}
+  onMouseLeave={[Function]}
+  type="button"
+>
+  <span
+    aria-describedby={null}
+    className="sc-iqAclL hWlKVA"
+    color="icon"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onMouseLeave={[Function]}
+    onMouseOver={[Function]}
+    onTouchEnd={[Function]}
+    onTouchStart={[Function]}
+    title="Copy to clipboard"
+  >
+    <svg
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="none"
+        fillRule="evenodd"
+      >
+        <path
+          d="M0 0H16V16H0z"
+        />
+        <path
+          className="icon-color"
+          d="M5.988 7.77c.008.07.011.141.011.214 0 .078-.004.154-.013.23l4.962 3.094c.302-.185.658-.292 1.038-.292 1.097 0 1.988.89 1.988 1.987 0 1.098-.89 1.987-1.988 1.987-1.098 0-1.988-.889-1.988-1.987 0-.092.007-.183.019-.272L5.092 9.66c-.314.205-.69.324-1.092.324-1.104 0-2-.896-2-2s.896-2 2-2c.408 0 .788.122 1.105.333l4.897-3.065c-.01-.083-.016-.167-.016-.252 0-1.105.896-2 2-2s2 .895 2 2c0 1.104-.896 2-2 2-.395 0-.763-.115-1.074-.313L5.988 7.77z"
+        />
+      </g>
+    </svg>
+  </span>
+</button>
+`;


### PR DESCRIPTION
## What it solves
[Transaction deeplinking](https://github.com/gnosis/safe-react/issues/970) preparation

## How this PR fixes it
The option of selecting the `<CopyToClipboardBtn>` icon `type` is now possible via props.