### PR TITLE
Bump version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-components",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Gnosis UI components",
   "main": "dist/index.min.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
The npm release failed on the previous commit to `main` because I didn't increase the version number. I've bumped it here in order for it to succeed.