### PR TITLE
Add step to upload production build

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -76,6 +76,10 @@ jobs:
         env:
           REVIEW_FEATURE_URL: https://pr${{ github.event.number }}--safereactcomponents.review.gnosisdev.com
 
+      # Script to upload release files
+      - name: 'Upload release build files for production'
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: aws s3 sync build s3://${{ secrets.STAGING_BUCKET_NAME }}/releases/${{ github.event.release.tag_name }} --delete
 
       # Script to prepare production deployments
       - run: bash ./scripts/github/prepare_production_deployment.sh

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-components",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Gnosis UI components",
   "main": "dist/index.min.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
There was one step missing on CI so we were able to upload production files in order to be deployed to the correct environment.