### PR TITLE
style: Adjust EthHashInfo name font weight

### DIFF
--- a/src/ethereum/EthHashInfo/index.tsx
+++ b/src/ethereum/EthHashInfo/index.tsx
@@ -47,7 +47,7 @@ type Props = {
   showHash?: boolean;
   shortenHash?: number;
   name?: string;
-  boldName?: boolean;
+  strongName?: boolean;
   textColor?: ThemeColors;
   textSize?: ThemeTextSize;
   showAvatar?: boolean;
@@ -82,7 +82,7 @@ const EthHashInfo = ({
   hash,
   showHash = true,
   name,
-  boldName = false,
+  strongName = false,
   textColor = 'text',
   textSize = 'lg',
   className,
@@ -127,7 +127,7 @@ const EthHashInfo = ({
 
       <InfoContainer>
         {name && (
-          <Text size={textSize} color={textColor} strong={boldName}>
+          <Text size={textSize} color={textColor} strong={strongName}>
             {name}
           </Text>
         )}

--- a/src/ethereum/EthHashInfo/index.tsx
+++ b/src/ethereum/EthHashInfo/index.tsx
@@ -125,7 +125,7 @@ const EthHashInfo = ({
 
       <InfoContainer>
         {name && (
-          <Text size={textSize} color={textColor}>
+          <Text size={textSize} color={textColor} strong>
             {name}
           </Text>
         )}

--- a/src/ethereum/EthHashInfo/index.tsx
+++ b/src/ethereum/EthHashInfo/index.tsx
@@ -47,6 +47,7 @@ type Props = {
   showHash?: boolean;
   shortenHash?: number;
   name?: string;
+  boldName?: boolean;
   textColor?: ThemeColors;
   textSize?: ThemeTextSize;
   showAvatar?: boolean;
@@ -81,6 +82,7 @@ const EthHashInfo = ({
   hash,
   showHash = true,
   name,
+  boldName = false,
   textColor = 'text',
   textSize = 'lg',
   className,
@@ -125,7 +127,7 @@ const EthHashInfo = ({
 
       <InfoContainer>
         {name && (
-          <Text size={textSize} color={textColor} strong>
+          <Text size={textSize} color={textColor} strong={boldName}>
             {name}
           </Text>
         )}


### PR DESCRIPTION
## Goal

In order to conform with the redesign of Tx Modals the name in `EthHashInfo` should be bold.

## Screenshot

![](https://user-images.githubusercontent.com/4503659/151728973-cc32eb49-1e4c-41a6-bce6-51d1ff766a91.png)

