### PR TITLE
Fix <AddressInput /> component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-components",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Gnosis UI components",
   "main": "dist/index.min.js",
   "typings": "dist/index.d.ts",

--- a/src/inputs/AddressInput/index.tsx
+++ b/src/inputs/AddressInput/index.tsx
@@ -51,9 +51,12 @@ function AddressInput({
   ...rest
 }: AddressInputProps): ReactElement {
   const [isLoadingENSResolution, setIsLoadingENSResolution] = useState(false);
-  const [inputValue, setInputValue] = useState('');
-  const defaulInputValue = addPrefix(address, networkPrefix, showNetworkPrefix);
-  const inputRef = useRef({ value: defaulInputValue });
+  const defaultInputValue = addPrefix(
+    address,
+    networkPrefix,
+    showNetworkPrefix
+  );
+  const inputRef = useRef({ value: defaultInputValue });
   const throttle = useThrottle();
 
   // we checksum & include the network prefix in the input if showNetworkPrefix is set to true
@@ -134,7 +137,6 @@ function AddressInput({
       );
 
       onChangeAddress(checksumAddress);
-      setInputValue(checksumAddress);
     },
     [networkPrefix, onChangeAddress]
   );
@@ -151,7 +153,7 @@ function AddressInput({
 
   const isLoading = isLoadingENSResolution || showLoadingSpinner;
 
-  const [shrink, setshrink] = useState(!!defaulInputValue);
+  const [shrink, setshrink] = useState(!!defaultInputValue);
 
   useEffect(() => {
     setshrink(!!inputRef.current?.value);
@@ -163,7 +165,6 @@ function AddressInput({
       hiddenLabel={hiddenLabel && !shrink}
       disabled={disabled || isLoadingENSResolution}
       onChange={onChange}
-      value={inputValue}
       InputProps={{
         ...InputProps,
         // if isLoading we show a custom loader adornment

--- a/src/inputs/Select/index.tsx
+++ b/src/inputs/Select/index.tsx
@@ -44,6 +44,7 @@ function Select({
   onItemClick,
   fallbackImage,
   fullWidth,
+  disabled,
   ...rest
 }: SelectProps): React.ReactElement {
   const [open, setOpen] = React.useState(false);
@@ -72,8 +73,12 @@ function Select({
   };
 
   return (
-    <StyledFormControl variant="outlined" fullWidth={fullWidth}>
-      <InputLabel error={!!error}>
+    <StyledFormControl
+      variant="outlined"
+      fullWidth={fullWidth}
+      error={hasError}
+      disabled={disabled}>
+      <InputLabel error={hasError} disabled={disabled}>
         {showErrorsInTheLabel && hasError ? error : label}
       </InputLabel>
       <StyledSelect
@@ -88,6 +93,7 @@ function Select({
         onChange={handleChange}
         label={id ? id : 'generic-select'}
         variant="outlined"
+        disabled={disabled}
         {...rest}>
         {items.map((i) => {
           return (

--- a/src/inputs/TextFieldInput/TextFieldInput.stories.tsx
+++ b/src/inputs/TextFieldInput/TextFieldInput.stories.tsx
@@ -193,3 +193,18 @@ export const FullWidthTextField = (): React.ReactElement => {
     </div>
   );
 };
+
+export const HelperText = (): React.ReactElement => {
+  const [value, setValue] = useState<string>('');
+  return (
+    <TextFieldInput
+      id="standard-TextFieldInput"
+      label="TextFieldInput"
+      name="TextFieldInput"
+      placeholder="TextFieldInput with default values"
+      value={value}
+      helperText="This is a helper text"
+      onChange={(e) => setValue(e.target.value)}
+    />
+  );
+};

--- a/src/inputs/TextFieldInput/index.tsx
+++ b/src/inputs/TextFieldInput/index.tsx
@@ -1,12 +1,7 @@
 import React, { ReactElement } from 'react';
 import TextFieldMui, { TextFieldProps } from '@material-ui/core/TextField';
 import styled from 'styled-components';
-import {
-  errorStyles,
-  inputLabelStyles,
-  inputStyles,
-  StyledTextFieldProps,
-} from '../styles';
+import { errorStyles, inputLabelStyles, inputStyles } from '../styles';
 
 export type TextFieldInputProps = {
   id?: string;
@@ -37,12 +32,11 @@ function TextFieldInput({
       name={name}
       label={showErrorsInTheLabel && hasError ? error : label}
       value={value}
-      helperText={hasError ? error : helperText}
+      helperText={!showErrorsInTheLabel && hasError ? error : helperText}
       error={hasError}
       color="primary"
       variant="outlined"
       hiddenLabel={hiddenLabel}
-      showErrorsInTheLabel={showErrorsInTheLabel}
       InputLabelProps={{
         ...rest.InputLabelProps,
         shrink: hiddenLabel || undefined,
@@ -52,7 +46,7 @@ function TextFieldInput({
   );
 }
 
-const TextField = styled((props: StyledTextFieldProps) => (
+const TextField = styled((props: TextFieldProps) => (
   <TextFieldMui {...props} />
 ))<TextFieldProps>`
   && {

--- a/src/inputs/styles.ts
+++ b/src/inputs/styles.ts
@@ -72,11 +72,13 @@ export const inputStyles = css<StyledTextFieldProps>`
         display: ${({ hiddenLabel }) => (hiddenLabel ? 'none' : 'block')};
       }
     }
+
     &:hover {
       .MuiOutlinedInput-notchedOutline {
         border-color: ${({ theme }) => theme.colors.primary};
       }
     }
+
     &.Mui-focused {
       .MuiOutlinedInput-notchedOutline {
         border-color: ${({ theme }) => theme.colors.inputFilled};
@@ -92,6 +94,14 @@ export const inputStyles = css<StyledTextFieldProps>`
         border-color: ${({ theme }) => theme.colors.inputDisabled};
       }
     }
+  }
+  .MuiFormLabel-filled
+    + .MuiOutlinedInput-root:not(:hover):not(.Mui-disabled)
+    .MuiOutlinedInput-notchedOutline {
+    border-color: ${({ theme, error, ...rest }) => {
+      console.log({ theme, error, ...rest });
+      return error ? theme.colors.error : theme.colors.inputFilled;
+    }};
   }
 `;
 

--- a/src/inputs/styles.ts
+++ b/src/inputs/styles.ts
@@ -98,10 +98,8 @@ export const inputStyles = css<StyledTextFieldProps>`
   .MuiFormLabel-filled
     + .MuiOutlinedInput-root:not(:hover):not(.Mui-disabled)
     .MuiOutlinedInput-notchedOutline {
-    border-color: ${({ theme, error, ...rest }) => {
-      console.log({ theme, error, ...rest });
-      return error ? theme.colors.error : theme.colors.inputFilled;
-    }};
+    border-color: ${({ theme, error }) =>
+      error ? theme.colors.error : theme.colors.inputFilled};
   }
 `;
 

--- a/src/inputs/styles.ts
+++ b/src/inputs/styles.ts
@@ -1,11 +1,7 @@
 import { TextFieldProps } from '@material-ui/core';
 import { css } from 'styled-components';
 
-export type StyledTextFieldProps = {
-  showErrorsInTheLabel?: boolean | undefined;
-} & TextFieldProps;
-
-export const inputLabelStyles = css<StyledTextFieldProps>`
+export const inputLabelStyles = css<TextFieldProps>`
   &:hover {
     .MuiInputLabel-root {
       &.MuiInputLabel-shrink:not(.Mui-focused):not(.Mui-disabled) {
@@ -47,7 +43,7 @@ export const inputLabelStyles = css<StyledTextFieldProps>`
   }
 `;
 
-export const inputStyles = css<StyledTextFieldProps>`
+export const inputStyles = css<TextFieldProps>`
   .MuiOutlinedInput-root {
     font-family: ${({ theme }) => theme.fonts.fontFamily};
     color: ${({ theme }) => theme.colors.inputText};
@@ -103,7 +99,7 @@ export const inputStyles = css<StyledTextFieldProps>`
   }
 `;
 
-export const errorStyles = css<StyledTextFieldProps>`
+export const errorStyles = css<TextFieldProps>`
   .Mui-error {
     &:hover,
     .Mui-focused {
@@ -113,12 +109,6 @@ export const errorStyles = css<StyledTextFieldProps>`
     }
     .MuiOutlinedInput-notchedOutline {
       border-color: ${({ theme }) => theme.colors.error};
-    }
-
-    .MuiFormHelperText-root.Mui-error {
-      font-family: ${({ theme }) => theme.fonts.fontFamily};
-      ${({ error, showErrorsInTheLabel }) =>
-        error && showErrorsInTheLabel ? `display: none` : ''}
     }
   }
 `;

--- a/tests/inputs/AddressInput/__snapshots__/AddressInput.stories.storyshot
+++ b/tests/inputs/AddressInput/__snapshots__/AddressInput.stories.storyshot
@@ -7,7 +7,7 @@ exports[`Storyshots Inputs/AddressInput Address Input Disabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiTextField-root sc-gWXbKe deKauR"
+    className="MuiFormControl-root MuiTextField-root sc-gWXbKe iXmoqd"
     spellCheck={false}
   >
     <label
@@ -36,7 +36,6 @@ exports[`Storyshots Inputs/AddressInput Address Input Disabled 1`] = `
         placeholder="Ethereum address"
         required={false}
         type="text"
-        value=""
       />
       <fieldset
         aria-hidden={true}
@@ -62,7 +61,7 @@ exports[`Storyshots Inputs/AddressInput Address Input Loading 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiTextField-root sc-gWXbKe BaIDq"
+    className="MuiFormControl-root MuiTextField-root sc-gWXbKe isyZpW"
     spellCheck={false}
   >
     <label
@@ -91,7 +90,6 @@ exports[`Storyshots Inputs/AddressInput Address Input Loading 1`] = `
         placeholder="Ethereum address"
         required={false}
         type="text"
-        value=""
       />
       <div
         className="MuiInputAdornment-root MuiInputAdornment-positionEnd"
@@ -146,7 +144,7 @@ exports[`Storyshots Inputs/AddressInput Address Input With Adornment 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiTextField-root sc-gWXbKe BaIDq"
+    className="MuiFormControl-root MuiTextField-root sc-gWXbKe isyZpW"
     spellCheck={false}
   >
     <label
@@ -175,7 +173,6 @@ exports[`Storyshots Inputs/AddressInput Address Input With Adornment 1`] = `
         placeholder="Ethereum address"
         required={false}
         type="text"
-        value=""
       />
       <div
         className="MuiInputAdornment-root MuiInputAdornment-positionEnd"
@@ -267,7 +264,7 @@ exports[`Storyshots Inputs/AddressInput Address Input With ENS Resolution 1`] = 
     }
   >
     <div
-      className="MuiFormControl-root MuiTextField-root sc-gWXbKe BaIDq"
+      className="MuiFormControl-root MuiTextField-root sc-gWXbKe isyZpW"
       spellCheck={false}
     >
       <label
@@ -297,7 +294,6 @@ exports[`Storyshots Inputs/AddressInput Address Input With ENS Resolution 1`] = 
           placeholder="Type safe.test to check ENS resolution"
           required={false}
           type="text"
-          value=""
         />
         <fieldset
           aria-hidden={true}
@@ -330,7 +326,7 @@ exports[`Storyshots Inputs/AddressInput Address Input With ENS Resolution 1`] = 
     }
   >
     <div
-      className="MuiFormControl-root MuiTextField-root sc-gWXbKe ciMulG"
+      className="MuiFormControl-root MuiTextField-root sc-gWXbKe keMErq"
     >
       <label
         className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
@@ -402,7 +398,7 @@ exports[`Storyshots Inputs/AddressInput Address Input With Errors 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiTextField-root sc-gWXbKe BaIDq"
+    className="MuiFormControl-root MuiTextField-root sc-gWXbKe dUdlfd"
     spellCheck={false}
   >
     <label
@@ -432,7 +428,6 @@ exports[`Storyshots Inputs/AddressInput Address Input With Errors 1`] = `
         placeholder="Ethereum address"
         required={false}
         type="text"
-        value=""
       />
       <fieldset
         aria-hidden={true}
@@ -464,7 +459,7 @@ exports[`Storyshots Inputs/AddressInput Address Input With Simple Address Valida
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiTextField-root sc-gWXbKe BaIDq"
+    className="MuiFormControl-root MuiTextField-root sc-gWXbKe isyZpW"
     spellCheck={false}
   >
     <label
@@ -493,7 +488,6 @@ exports[`Storyshots Inputs/AddressInput Address Input With Simple Address Valida
         placeholder="Ethereum address"
         required={false}
         type="text"
-        value=""
       />
       <fieldset
         aria-hidden={true}
@@ -529,7 +523,7 @@ exports[`Storyshots Inputs/AddressInput Address Input Without Prefix 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiTextField-root sc-gWXbKe BaIDq"
+    className="MuiFormControl-root MuiTextField-root sc-gWXbKe isyZpW"
     spellCheck={false}
   >
     <label
@@ -558,7 +552,6 @@ exports[`Storyshots Inputs/AddressInput Address Input Without Prefix 1`] = `
         placeholder="Ethereum address"
         required={false}
         type="text"
-        value=""
       />
       <fieldset
         aria-hidden={true}
@@ -612,7 +605,7 @@ exports[`Storyshots Inputs/AddressInput Safe Address Input Validation 1`] = `
     className="MuiTypography-root sc-fbyfCU iNHYoN MuiTypography-body1"
   />
   <div
-    className="MuiFormControl-root MuiTextField-root sc-gWXbKe BaIDq"
+    className="MuiFormControl-root MuiTextField-root sc-gWXbKe isyZpW"
     showErrorsInTheLabel={false}
     spellCheck={false}
   >
@@ -643,7 +636,6 @@ exports[`Storyshots Inputs/AddressInput Safe Address Input Validation 1`] = `
         placeholder="Type the valid safe address"
         required={false}
         type="text"
-        value=""
       />
       <fieldset
         aria-hidden={true}
@@ -686,7 +678,7 @@ exports[`Storyshots Inputs/AddressInput Simple Address Input 1`] = `
     Network Settings:
   </p>
   <div
-    className="MuiFormControl-root sc-kLwhqv UVNmp"
+    className="MuiFormControl-root sc-kLwhqv bLnoLt"
   >
     <label
       className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
@@ -766,7 +758,7 @@ exports[`Storyshots Inputs/AddressInput Simple Address Input 1`] = `
     }
   >
     <div
-      className="MuiFormControl-root MuiTextField-root sc-gWXbKe BaIDq"
+      className="MuiFormControl-root MuiTextField-root sc-gWXbKe isyZpW"
       spellCheck={false}
     >
       <label
@@ -795,7 +787,6 @@ exports[`Storyshots Inputs/AddressInput Simple Address Input 1`] = `
           placeholder="Ethereum address"
           required={false}
           type="text"
-          value=""
         />
         <fieldset
           aria-hidden={true}

--- a/tests/inputs/AddressInput/__snapshots__/AddressInput.stories.storyshot
+++ b/tests/inputs/AddressInput/__snapshots__/AddressInput.stories.storyshot
@@ -7,7 +7,7 @@ exports[`Storyshots Inputs/AddressInput Address Input Disabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiTextField-root sc-gWXbKe iXmoqd"
+    className="MuiFormControl-root MuiTextField-root sc-gWXbKe kexQVt"
     spellCheck={false}
   >
     <label
@@ -61,7 +61,7 @@ exports[`Storyshots Inputs/AddressInput Address Input Loading 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiTextField-root sc-gWXbKe isyZpW"
+    className="MuiFormControl-root MuiTextField-root sc-gWXbKe eRauOW"
     spellCheck={false}
   >
     <label
@@ -144,7 +144,7 @@ exports[`Storyshots Inputs/AddressInput Address Input With Adornment 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiTextField-root sc-gWXbKe isyZpW"
+    className="MuiFormControl-root MuiTextField-root sc-gWXbKe eRauOW"
     spellCheck={false}
   >
     <label
@@ -264,7 +264,7 @@ exports[`Storyshots Inputs/AddressInput Address Input With ENS Resolution 1`] = 
     }
   >
     <div
-      className="MuiFormControl-root MuiTextField-root sc-gWXbKe isyZpW"
+      className="MuiFormControl-root MuiTextField-root sc-gWXbKe eRauOW"
       spellCheck={false}
     >
       <label
@@ -326,7 +326,7 @@ exports[`Storyshots Inputs/AddressInput Address Input With ENS Resolution 1`] = 
     }
   >
     <div
-      className="MuiFormControl-root MuiTextField-root sc-gWXbKe keMErq"
+      className="MuiFormControl-root MuiTextField-root sc-gWXbKe flGugG"
     >
       <label
         className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
@@ -398,7 +398,7 @@ exports[`Storyshots Inputs/AddressInput Address Input With Errors 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiTextField-root sc-gWXbKe dUdlfd"
+    className="MuiFormControl-root MuiTextField-root sc-gWXbKe fynudp"
     spellCheck={false}
   >
     <label
@@ -459,7 +459,7 @@ exports[`Storyshots Inputs/AddressInput Address Input With Simple Address Valida
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiTextField-root sc-gWXbKe isyZpW"
+    className="MuiFormControl-root MuiTextField-root sc-gWXbKe eRauOW"
     spellCheck={false}
   >
     <label
@@ -523,7 +523,7 @@ exports[`Storyshots Inputs/AddressInput Address Input Without Prefix 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiTextField-root sc-gWXbKe isyZpW"
+    className="MuiFormControl-root MuiTextField-root sc-gWXbKe eRauOW"
     spellCheck={false}
   >
     <label
@@ -605,8 +605,7 @@ exports[`Storyshots Inputs/AddressInput Safe Address Input Validation 1`] = `
     className="MuiTypography-root sc-fbyfCU iNHYoN MuiTypography-body1"
   />
   <div
-    className="MuiFormControl-root MuiTextField-root sc-gWXbKe isyZpW"
-    showErrorsInTheLabel={false}
+    className="MuiFormControl-root MuiTextField-root sc-gWXbKe eRauOW"
     spellCheck={false}
   >
     <label
@@ -678,7 +677,7 @@ exports[`Storyshots Inputs/AddressInput Simple Address Input 1`] = `
     Network Settings:
   </p>
   <div
-    className="MuiFormControl-root sc-kLwhqv bLnoLt"
+    className="MuiFormControl-root sc-kLwhqv hCASnh"
   >
     <label
       className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
@@ -758,7 +757,7 @@ exports[`Storyshots Inputs/AddressInput Simple Address Input 1`] = `
     }
   >
     <div
-      className="MuiFormControl-root MuiTextField-root sc-gWXbKe isyZpW"
+      className="MuiFormControl-root MuiTextField-root sc-gWXbKe eRauOW"
       spellCheck={false}
     >
       <label

--- a/tests/inputs/Select/__snapshots__/select.stories.storyshot
+++ b/tests/inputs/Select/__snapshots__/select.stories.storyshot
@@ -9,7 +9,7 @@ exports[`Storyshots Inputs/Select Disabled Select 1`] = `
   }
 >
   <div
-    className="MuiFormControl-root sc-kLwhqv ksYMUG MuiFormControl-fullWidth"
+    className="MuiFormControl-root sc-kLwhqv jgEbCK MuiFormControl-fullWidth"
   >
     <label
       className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined Mui-disabled Mui-disabled"
@@ -88,7 +88,7 @@ exports[`Storyshots Inputs/Select Error Select 1`] = `
   }
 >
   <div
-    className="MuiFormControl-root sc-kLwhqv dxJMlq"
+    className="MuiFormControl-root sc-kLwhqv hrOGDS"
   >
     <label
       className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined Mui-error Mui-error"
@@ -171,7 +171,7 @@ exports[`Storyshots Inputs/Select Simple Select 1`] = `
   }
 >
   <div
-    className="MuiFormControl-root sc-kLwhqv bLnoLt MuiFormControl-fullWidth"
+    className="MuiFormControl-root sc-kLwhqv hCASnh MuiFormControl-fullWidth"
   >
     <label
       className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"

--- a/tests/inputs/Select/__snapshots__/select.stories.storyshot
+++ b/tests/inputs/Select/__snapshots__/select.stories.storyshot
@@ -9,10 +9,10 @@ exports[`Storyshots Inputs/Select Disabled Select 1`] = `
   }
 >
   <div
-    className="MuiFormControl-root sc-kLwhqv UVNmp MuiFormControl-fullWidth"
+    className="MuiFormControl-root sc-kLwhqv ksYMUG MuiFormControl-fullWidth"
   >
     <label
-      className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
+      className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined Mui-disabled Mui-disabled"
       data-shrink={false}
     >
       Select Token
@@ -88,7 +88,7 @@ exports[`Storyshots Inputs/Select Error Select 1`] = `
   }
 >
   <div
-    className="MuiFormControl-root sc-kLwhqv UVNmp"
+    className="MuiFormControl-root sc-kLwhqv dxJMlq"
   >
     <label
       className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined Mui-error Mui-error"
@@ -171,7 +171,7 @@ exports[`Storyshots Inputs/Select Simple Select 1`] = `
   }
 >
   <div
-    className="MuiFormControl-root sc-kLwhqv UVNmp MuiFormControl-fullWidth"
+    className="MuiFormControl-root sc-kLwhqv bLnoLt MuiFormControl-fullWidth"
   >
     <label
       className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"

--- a/tests/inputs/TextFieldInput/__snapshots__/TextFieldInput.stories.storyshot
+++ b/tests/inputs/TextFieldInput/__snapshots__/TextFieldInput.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots Inputs/TextFieldInput Disabled Text Field 1`] = `
 <div
-  className="MuiFormControl-root MuiTextField-root sc-gWXbKe iXSnpx"
+  className="MuiFormControl-root MuiTextField-root sc-gWXbKe cBhCvN"
 >
   <label
     className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-disabled Mui-disabled MuiFormLabel-filled"
@@ -49,7 +49,7 @@ exports[`Storyshots Inputs/TextFieldInput Disabled Text Field 1`] = `
 
 exports[`Storyshots Inputs/TextFieldInput End Adornment Text Field 1`] = `
 <div
-  className="MuiFormControl-root MuiTextField-root sc-gWXbKe BaIDq"
+  className="MuiFormControl-root MuiTextField-root sc-gWXbKe isyZpW"
 >
   <label
     className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
@@ -135,7 +135,7 @@ exports[`Storyshots Inputs/TextFieldInput Full Width Text Field 1`] = `
   }
 >
   <div
-    className="MuiFormControl-root MuiTextField-root sc-gWXbKe BaIDq MuiFormControl-fullWidth"
+    className="MuiFormControl-root MuiTextField-root sc-gWXbKe isyZpW MuiFormControl-fullWidth"
   >
     <label
       className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
@@ -184,7 +184,7 @@ exports[`Storyshots Inputs/TextFieldInput Full Width Text Field 1`] = `
 
 exports[`Storyshots Inputs/TextFieldInput Number Text Field 1`] = `
 <div
-  className="MuiFormControl-root MuiTextField-root sc-gWXbKe ciMulG"
+  className="MuiFormControl-root MuiTextField-root sc-gWXbKe keMErq"
 >
   <label
     className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
@@ -231,7 +231,7 @@ exports[`Storyshots Inputs/TextFieldInput Number Text Field 1`] = `
 
 exports[`Storyshots Inputs/TextFieldInput Simple Text Field 1`] = `
 <div
-  className="MuiFormControl-root MuiTextField-root sc-gWXbKe BaIDq"
+  className="MuiFormControl-root MuiTextField-root sc-gWXbKe isyZpW"
 >
   <label
     className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
@@ -279,7 +279,7 @@ exports[`Storyshots Inputs/TextFieldInput Simple Text Field 1`] = `
 
 exports[`Storyshots Inputs/TextFieldInput Start Adornment Text Field 1`] = `
 <div
-  className="MuiFormControl-root MuiTextField-root sc-gWXbKe BaIDq"
+  className="MuiFormControl-root MuiTextField-root sc-gWXbKe isyZpW"
 >
   <label
     className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
@@ -358,7 +358,7 @@ exports[`Storyshots Inputs/TextFieldInput Start Adornment Text Field 1`] = `
 
 exports[`Storyshots Inputs/TextFieldInput Text Field With Errors 1`] = `
 <div
-  className="MuiFormControl-root MuiTextField-root sc-gWXbKe ciMulG"
+  className="MuiFormControl-root MuiTextField-root sc-gWXbKe fNHANZ"
 >
   <label
     className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-error Mui-error MuiFormLabel-filled"
@@ -539,7 +539,7 @@ Array [
     Show Errors in The Label
   </p>,
   <div
-    className="MuiFormControl-root MuiTextField-root sc-gWXbKe BaIDq"
+    className="MuiFormControl-root MuiTextField-root sc-gWXbKe dUdlfd"
     showErrorsInTheLabel={false}
   >
     <label
@@ -639,7 +639,7 @@ Array [
     </span>
   </p>,
   <div
-    className="MuiFormControl-root MuiTextField-root sc-gWXbKe QENhr"
+    className="MuiFormControl-root MuiTextField-root sc-gWXbKe dpxtRj"
   >
     <label
       className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"

--- a/tests/inputs/TextFieldInput/__snapshots__/TextFieldInput.stories.storyshot
+++ b/tests/inputs/TextFieldInput/__snapshots__/TextFieldInput.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots Inputs/TextFieldInput Disabled Text Field 1`] = `
 <div
-  className="MuiFormControl-root MuiTextField-root sc-gWXbKe cBhCvN"
+  className="MuiFormControl-root MuiTextField-root sc-gWXbKe dwZvEp"
 >
   <label
     className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-disabled Mui-disabled MuiFormLabel-filled"
@@ -49,7 +49,7 @@ exports[`Storyshots Inputs/TextFieldInput Disabled Text Field 1`] = `
 
 exports[`Storyshots Inputs/TextFieldInput End Adornment Text Field 1`] = `
 <div
-  className="MuiFormControl-root MuiTextField-root sc-gWXbKe isyZpW"
+  className="MuiFormControl-root MuiTextField-root sc-gWXbKe eRauOW"
 >
   <label
     className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
@@ -135,7 +135,7 @@ exports[`Storyshots Inputs/TextFieldInput Full Width Text Field 1`] = `
   }
 >
   <div
-    className="MuiFormControl-root MuiTextField-root sc-gWXbKe isyZpW MuiFormControl-fullWidth"
+    className="MuiFormControl-root MuiTextField-root sc-gWXbKe eRauOW MuiFormControl-fullWidth"
   >
     <label
       className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
@@ -182,9 +182,64 @@ exports[`Storyshots Inputs/TextFieldInput Full Width Text Field 1`] = `
 </div>
 `;
 
+exports[`Storyshots Inputs/TextFieldInput Helper Text 1`] = `
+<div
+  className="MuiFormControl-root MuiTextField-root sc-gWXbKe eRauOW"
+>
+  <label
+    className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
+    data-shrink={false}
+    htmlFor="standard-TextFieldInput"
+    id="standard-TextFieldInput-label"
+  >
+    TextFieldInput
+  </label>
+  <div
+    className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
+    onClick={[Function]}
+  >
+    <input
+      aria-describedby="standard-TextFieldInput-helper-text"
+      aria-invalid={false}
+      autoFocus={false}
+      className="MuiInputBase-input MuiOutlinedInput-input"
+      disabled={false}
+      id="standard-TextFieldInput"
+      name="TextFieldInput"
+      onAnimationStart={[Function]}
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      placeholder="TextFieldInput with default values"
+      required={false}
+      type="text"
+      value=""
+    />
+    <fieldset
+      aria-hidden={true}
+      className="PrivateNotchedOutline-root-141 MuiOutlinedInput-notchedOutline"
+    >
+      <legend
+        className="PrivateNotchedOutline-legendLabelled-143"
+      >
+        <span>
+          TextFieldInput
+        </span>
+      </legend>
+    </fieldset>
+  </div>
+  <p
+    className="MuiFormHelperText-root MuiFormHelperText-contained"
+    id="standard-TextFieldInput-helper-text"
+  >
+    This is a helper text
+  </p>
+</div>
+`;
+
 exports[`Storyshots Inputs/TextFieldInput Number Text Field 1`] = `
 <div
-  className="MuiFormControl-root MuiTextField-root sc-gWXbKe keMErq"
+  className="MuiFormControl-root MuiTextField-root sc-gWXbKe flGugG"
 >
   <label
     className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
@@ -215,10 +270,10 @@ exports[`Storyshots Inputs/TextFieldInput Number Text Field 1`] = `
     />
     <fieldset
       aria-hidden={true}
-      className="PrivateNotchedOutline-root-141 MuiOutlinedInput-notchedOutline"
+      className="PrivateNotchedOutline-root-145 MuiOutlinedInput-notchedOutline"
     >
       <legend
-        className="PrivateNotchedOutline-legendLabelled-143 PrivateNotchedOutline-legendNotched-144"
+        className="PrivateNotchedOutline-legendLabelled-147 PrivateNotchedOutline-legendNotched-148"
       >
         <span>
           Number
@@ -231,7 +286,7 @@ exports[`Storyshots Inputs/TextFieldInput Number Text Field 1`] = `
 
 exports[`Storyshots Inputs/TextFieldInput Simple Text Field 1`] = `
 <div
-  className="MuiFormControl-root MuiTextField-root sc-gWXbKe isyZpW"
+  className="MuiFormControl-root MuiTextField-root sc-gWXbKe eRauOW"
 >
   <label
     className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
@@ -263,10 +318,10 @@ exports[`Storyshots Inputs/TextFieldInput Simple Text Field 1`] = `
     />
     <fieldset
       aria-hidden={true}
-      className="PrivateNotchedOutline-root-145 MuiOutlinedInput-notchedOutline"
+      className="PrivateNotchedOutline-root-149 MuiOutlinedInput-notchedOutline"
     >
       <legend
-        className="PrivateNotchedOutline-legendLabelled-147"
+        className="PrivateNotchedOutline-legendLabelled-151"
       >
         <span>
           TextFieldInput
@@ -279,7 +334,7 @@ exports[`Storyshots Inputs/TextFieldInput Simple Text Field 1`] = `
 
 exports[`Storyshots Inputs/TextFieldInput Start Adornment Text Field 1`] = `
 <div
-  className="MuiFormControl-root MuiTextField-root sc-gWXbKe isyZpW"
+  className="MuiFormControl-root MuiTextField-root sc-gWXbKe eRauOW"
 >
   <label
     className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
@@ -342,10 +397,10 @@ exports[`Storyshots Inputs/TextFieldInput Start Adornment Text Field 1`] = `
     />
     <fieldset
       aria-hidden={true}
-      className="PrivateNotchedOutline-root-149 MuiOutlinedInput-notchedOutline"
+      className="PrivateNotchedOutline-root-153 MuiOutlinedInput-notchedOutline"
     >
       <legend
-        className="PrivateNotchedOutline-legendLabelled-151 PrivateNotchedOutline-legendNotched-152"
+        className="PrivateNotchedOutline-legendLabelled-155 PrivateNotchedOutline-legendNotched-156"
       >
         <span>
           TextFieldInput
@@ -358,7 +413,7 @@ exports[`Storyshots Inputs/TextFieldInput Start Adornment Text Field 1`] = `
 
 exports[`Storyshots Inputs/TextFieldInput Text Field With Errors 1`] = `
 <div
-  className="MuiFormControl-root MuiTextField-root sc-gWXbKe fNHANZ"
+  className="MuiFormControl-root MuiTextField-root sc-gWXbKe bIHJuJ"
 >
   <label
     className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined Mui-error Mui-error MuiFormLabel-filled"
@@ -390,10 +445,10 @@ exports[`Storyshots Inputs/TextFieldInput Text Field With Errors 1`] = `
     />
     <fieldset
       aria-hidden={true}
-      className="PrivateNotchedOutline-root-153 MuiOutlinedInput-notchedOutline"
+      className="PrivateNotchedOutline-root-157 MuiOutlinedInput-notchedOutline"
     >
       <legend
-        className="PrivateNotchedOutline-legendLabelled-155 PrivateNotchedOutline-legendNotched-156"
+        className="PrivateNotchedOutline-legendLabelled-159 PrivateNotchedOutline-legendNotched-160"
       >
         <span>
           TextFieldInput
@@ -420,7 +475,7 @@ Array [
     >
       <span
         aria-disabled={false}
-        className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-157 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-158 Mui-checked"
+        className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-161 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-162 Mui-checked"
         onBlur={[Function]}
         onDragLeave={[Function]}
         onFocus={[Function]}
@@ -439,7 +494,7 @@ Array [
         >
           <input
             checked={true}
-            className="PrivateSwitchBase-input-160 MuiSwitch-input"
+            className="PrivateSwitchBase-input-164 MuiSwitch-input"
             onChange={[Function]}
             type="checkbox"
           />
@@ -462,7 +517,7 @@ Array [
     >
       <span
         aria-disabled={false}
-        className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-157 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+        className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-161 MuiSwitch-switchBase MuiSwitch-colorSecondary"
         onBlur={[Function]}
         onDragLeave={[Function]}
         onFocus={[Function]}
@@ -481,7 +536,7 @@ Array [
         >
           <input
             checked={false}
-            className="PrivateSwitchBase-input-160 MuiSwitch-input"
+            className="PrivateSwitchBase-input-164 MuiSwitch-input"
             onChange={[Function]}
             type="checkbox"
           />
@@ -504,7 +559,7 @@ Array [
     >
       <span
         aria-disabled={false}
-        className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-157 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+        className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-161 MuiSwitch-switchBase MuiSwitch-colorSecondary"
         onBlur={[Function]}
         onDragLeave={[Function]}
         onFocus={[Function]}
@@ -523,7 +578,7 @@ Array [
         >
           <input
             checked={false}
-            className="PrivateSwitchBase-input-160 MuiSwitch-input"
+            className="PrivateSwitchBase-input-164 MuiSwitch-input"
             onChange={[Function]}
             type="checkbox"
           />
@@ -539,8 +594,7 @@ Array [
     Show Errors in The Label
   </p>,
   <div
-    className="MuiFormControl-root MuiTextField-root sc-gWXbKe dUdlfd"
-    showErrorsInTheLabel={false}
+    className="MuiFormControl-root MuiTextField-root sc-gWXbKe fynudp"
   >
     <label
       className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined Mui-error Mui-error"
@@ -573,10 +627,10 @@ Array [
       />
       <fieldset
         aria-hidden={true}
-        className="PrivateNotchedOutline-root-161 MuiOutlinedInput-notchedOutline"
+        className="PrivateNotchedOutline-root-165 MuiOutlinedInput-notchedOutline"
       >
         <legend
-          className="PrivateNotchedOutline-legendLabelled-163"
+          className="PrivateNotchedOutline-legendLabelled-167"
         >
           <span>
             TextFieldInput
@@ -605,7 +659,7 @@ Array [
     >
       <span
         aria-disabled={false}
-        className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-165 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-166 Mui-checked"
+        className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-169 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-checked-170 Mui-checked"
         onBlur={[Function]}
         onDragLeave={[Function]}
         onFocus={[Function]}
@@ -624,7 +678,7 @@ Array [
         >
           <input
             checked={true}
-            className="PrivateSwitchBase-input-168 MuiSwitch-input"
+            className="PrivateSwitchBase-input-172 MuiSwitch-input"
             onChange={[Function]}
             type="checkbox"
           />
@@ -639,7 +693,7 @@ Array [
     </span>
   </p>,
   <div
-    className="MuiFormControl-root MuiTextField-root sc-gWXbKe dpxtRj"
+    className="MuiFormControl-root MuiTextField-root sc-gWXbKe giQUEX"
   >
     <label
       className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
@@ -671,10 +725,10 @@ Array [
       />
       <fieldset
         aria-hidden={true}
-        className="PrivateNotchedOutline-root-169 MuiOutlinedInput-notchedOutline"
+        className="PrivateNotchedOutline-root-173 MuiOutlinedInput-notchedOutline"
       >
         <legend
-          className="PrivateNotchedOutline-legendLabelled-171 PrivateNotchedOutline-legendNotched-172"
+          className="PrivateNotchedOutline-legendLabelled-175 PrivateNotchedOutline-legendNotched-176"
         >
           <span>
             TextFieldInput

--- a/tests/navigation/Tab/__snapshots__/tab.stories.storyshot
+++ b/tests/navigation/Tab/__snapshots__/tab.stories.storyshot
@@ -6,7 +6,7 @@ Array [
     className="sc-jObWnj hVMnVC"
   >
     <div
-      className="MuiTabs-root WithStyles(ForwardRef(Tabs))-root-173"
+      className="MuiTabs-root WithStyles(ForwardRef(Tabs))-root-177"
     >
       <div
         className="MuiTabs-scrollable"
@@ -37,7 +37,7 @@ Array [
         >
           <button
             aria-selected={false}
-            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-174 MuiTab-textColorInherit"
+            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-178 MuiTab-textColorInherit"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
@@ -101,7 +101,7 @@ Array [
           </button>
           <button
             aria-selected={false}
-            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-175 MuiTab-textColorInherit"
+            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-179 MuiTab-textColorInherit"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
@@ -160,7 +160,7 @@ Array [
           </button>
           <button
             aria-selected={true}
-            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-176 MuiTab-textColorInherit Mui-selected"
+            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-180 MuiTab-textColorInherit Mui-selected"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
@@ -226,13 +226,13 @@ Array [
               </div>
             </span>
             <span
-              className="PrivateTabIndicator-root-177 PrivateTabIndicator-colorSecondary-179 MuiTabs-indicator"
+              className="PrivateTabIndicator-root-181 PrivateTabIndicator-colorSecondary-183 MuiTabs-indicator"
               style={Object {}}
             />
           </button>
           <button
             aria-selected={false}
-            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-181 MuiTab-textColorInherit Mui-disabled Mui-disabled"
+            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-185 MuiTab-textColorInherit Mui-disabled Mui-disabled"
             disabled={true}
             onBlur={[Function]}
             onClick={[Function]}
@@ -292,7 +292,7 @@ Array [
           </button>
           <button
             aria-selected={false}
-            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-182 MuiTab-textColorInherit"
+            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-186 MuiTab-textColorInherit"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
@@ -332,7 +332,7 @@ Array [
     className="sc-jObWnj bbERZt"
   >
     <div
-      className="MuiTabs-root WithStyles(ForwardRef(Tabs))-root-183"
+      className="MuiTabs-root WithStyles(ForwardRef(Tabs))-root-187"
     >
       <div
         className="MuiTabs-scrollable"
@@ -363,7 +363,7 @@ Array [
         >
           <button
             aria-selected={false}
-            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-184 MuiTab-textColorInherit"
+            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-188 MuiTab-textColorInherit"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
@@ -427,7 +427,7 @@ Array [
           </button>
           <button
             aria-selected={false}
-            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-185 MuiTab-textColorInherit"
+            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-189 MuiTab-textColorInherit"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
@@ -486,7 +486,7 @@ Array [
           </button>
           <button
             aria-selected={true}
-            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-186 MuiTab-textColorInherit Mui-selected"
+            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-190 MuiTab-textColorInherit Mui-selected"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
@@ -552,13 +552,13 @@ Array [
               </div>
             </span>
             <span
-              className="PrivateTabIndicator-root-187 PrivateTabIndicator-colorSecondary-189 MuiTabs-indicator"
+              className="PrivateTabIndicator-root-191 PrivateTabIndicator-colorSecondary-193 MuiTabs-indicator"
               style={Object {}}
             />
           </button>
           <button
             aria-selected={false}
-            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-191 MuiTab-textColorInherit Mui-disabled Mui-disabled"
+            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-195 MuiTab-textColorInherit Mui-disabled Mui-disabled"
             disabled={true}
             onBlur={[Function]}
             onClick={[Function]}
@@ -618,7 +618,7 @@ Array [
           </button>
           <button
             aria-selected={false}
-            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-192 MuiTab-textColorInherit"
+            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-196 MuiTab-textColorInherit"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
@@ -658,7 +658,7 @@ Array [
     className="sc-jObWnj bbERZt"
   >
     <div
-      className="MuiTabs-root WithStyles(ForwardRef(Tabs))-root-193"
+      className="MuiTabs-root WithStyles(ForwardRef(Tabs))-root-197"
     >
       <div
         className="MuiTabs-scroller MuiTabs-fixed"
@@ -677,7 +677,7 @@ Array [
         >
           <button
             aria-selected={false}
-            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-194 MuiTab-textColorInherit MuiTab-fullWidth"
+            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-198 MuiTab-textColorInherit MuiTab-fullWidth"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
@@ -741,7 +741,7 @@ Array [
           </button>
           <button
             aria-selected={false}
-            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-195 MuiTab-textColorInherit MuiTab-fullWidth"
+            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-199 MuiTab-textColorInherit MuiTab-fullWidth"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
@@ -800,7 +800,7 @@ Array [
           </button>
           <button
             aria-selected={true}
-            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-196 MuiTab-textColorInherit Mui-selected MuiTab-fullWidth"
+            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-200 MuiTab-textColorInherit Mui-selected MuiTab-fullWidth"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
@@ -866,13 +866,13 @@ Array [
               </div>
             </span>
             <span
-              className="PrivateTabIndicator-root-197 PrivateTabIndicator-colorSecondary-199 MuiTabs-indicator"
+              className="PrivateTabIndicator-root-201 PrivateTabIndicator-colorSecondary-203 MuiTabs-indicator"
               style={Object {}}
             />
           </button>
           <button
             aria-selected={false}
-            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-201 MuiTab-textColorInherit Mui-disabled MuiTab-fullWidth Mui-disabled"
+            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-205 MuiTab-textColorInherit Mui-disabled MuiTab-fullWidth Mui-disabled"
             disabled={true}
             onBlur={[Function]}
             onClick={[Function]}
@@ -932,7 +932,7 @@ Array [
           </button>
           <button
             aria-selected={false}
-            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-202 MuiTab-textColorInherit MuiTab-fullWidth"
+            className="MuiButtonBase-root MuiTab-root WithStyles(ForwardRef(Tab))-root-206 MuiTab-textColorInherit MuiTab-fullWidth"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}


### PR DESCRIPTION
The AddressInput component is removing the network prefix on paste. This is because the changes in the major 1.0.0 so we remove the specific change and use a workaround to get the same visual behavior

We fix the disabled state as well on selects as did not match the designs