### PR TITLE
Fix/wrong label space calculation in selects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-components",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Gnosis UI components",
   "main": "dist/index.min.js",
   "typings": "dist/index.d.ts",

--- a/src/inputs/Select/index.tsx
+++ b/src/inputs/Select/index.tsx
@@ -91,7 +91,7 @@ function Select({
         onOpen={handleOpen}
         value={activeItemId}
         onChange={handleChange}
-        label={id ? id : 'generic-select'}
+        label={label}
         variant="outlined"
         disabled={disabled}
         {...rest}>

--- a/tests/inputs/AddressInput/__snapshots__/AddressInput.stories.storyshot
+++ b/tests/inputs/AddressInput/__snapshots__/AddressInput.stories.storyshot
@@ -739,7 +739,7 @@ exports[`Storyshots Inputs/AddressInput Simple Address Input 1`] = `
           className="PrivateNotchedOutline-legendLabelled-101 PrivateNotchedOutline-legendNotched-102"
         >
           <span>
-            generic-select
+            Network
           </span>
         </legend>
       </fieldset>

--- a/tests/inputs/Select/__snapshots__/select.stories.storyshot
+++ b/tests/inputs/Select/__snapshots__/select.stories.storyshot
@@ -70,7 +70,7 @@ exports[`Storyshots Inputs/Select Disabled Select 1`] = `
           className="PrivateNotchedOutline-legendLabelled-115"
         >
           <span>
-            error-select
+            Select Token
           </span>
         </legend>
       </fieldset>
@@ -148,7 +148,7 @@ exports[`Storyshots Inputs/Select Error Select 1`] = `
           className="PrivateNotchedOutline-legendLabelled-119"
         >
           <span>
-            error-select
+            Select Token
           </span>
         </legend>
       </fieldset>
@@ -231,7 +231,7 @@ exports[`Storyshots Inputs/Select Simple Select 1`] = `
           className="PrivateNotchedOutline-legendLabelled-123"
         >
           <span>
-            simple-select
+            Select Token
           </span>
         </legend>
       </fieldset>


### PR DESCRIPTION
# What it solves
Resolves https://github.com/gnosis/safe-react-apps/issues/361

There is a wrong calculation with label spacing with long labels