### PR TITLE
fix: Stroke in bookmark icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-components",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Gnosis UI components",
   "main": "dist/index.min.js",
   "typings": "dist/index.d.ts",

--- a/src/dataDisplay/Icon/images/bookmark.tsx
+++ b/src/dataDisplay/Icon/images/bookmark.tsx
@@ -12,7 +12,7 @@ export default {
         <path
           className="icon-stroke"
           d="M9 11L5 8.22222L1 11V2.11111C1 1.81643 1.12041 1.53381 1.33474 1.32544C1.54906 1.11706 1.83975 1 2.14286 1H7.85714C8.16025 1 8.45094 1.11706 8.66527 1.32544C8.87959 1.53381 9 1.81643 9 2.11111V11Z"
-          strokeWidth="1"
+          strokeWidth="2"
           strokeLinecap="round"
           strokeLinejoin="round"
         />
@@ -30,7 +30,7 @@ export default {
         <path
           className="icon-stroke"
           d="M9 11L5 8.22222L1 11V2.11111C1 1.81643 1.12041 1.53381 1.33474 1.32544C1.54906 1.11706 1.83975 1 2.14286 1H7.85714C8.16025 1 8.45094 1.11706 8.66527 1.32544C8.87959 1.53381 9 1.81643 9 2.11111V11Z"
-          strokeWidth="1"
+          strokeWidth="1.5"
           strokeLinecap="round"
           strokeLinejoin="round"
         />

--- a/src/dataDisplay/Icon/images/bookmarkFilled.tsx
+++ b/src/dataDisplay/Icon/images/bookmarkFilled.tsx
@@ -12,7 +12,7 @@ export default {
         <path
           className="icon-color icon-stroke"
           d="M9 11L5 8.22222L1 11V2.11111C1 1.81643 1.12041 1.53381 1.33474 1.32544C1.54906 1.11706 1.83975 1 2.14286 1H7.85714C8.16025 1 8.45094 1.11706 8.66527 1.32544C8.87959 1.53381 9 1.81643 9 2.11111V11Z"
-          strokeWidth="1"
+          strokeWidth="2"
           strokeLinecap="round"
           strokeLinejoin="round"
         />
@@ -30,7 +30,7 @@ export default {
         <path
           className="icon-color icon-stroke"
           d="M9 11L5 8.22222L1 11V2.11111C1 1.81643 1.12041 1.53381 1.33474 1.32544C1.54906 1.11706 1.83975 1 2.14286 1H7.85714C8.16025 1 8.45094 1.11706 8.66527 1.32544C8.87959 1.53381 9 1.81643 9 2.11111V11Z"
-          strokeWidth="1"
+          strokeWidth="1.5"
           strokeLinecap="round"
           strokeLinejoin="round"
         />

--- a/tests/dataDisplay/Icon/__snapshots__/icon.stories.storyshot
+++ b/tests/dataDisplay/Icon/__snapshots__/icon.stories.storyshot
@@ -546,7 +546,7 @@ exports[`Storyshots Data Display/Icon Icons 1`] = `
             d="M9 11L5 8.22222L1 11V2.11111C1 1.81643 1.12041 1.53381 1.33474 1.32544C1.54906 1.11706 1.83975 1 2.14286 1H7.85714C8.16025 1 8.45094 1.11706 8.66527 1.32544C8.87959 1.53381 9 1.81643 9 2.11111V11Z"
             strokeLinecap="round"
             strokeLinejoin="round"
-            strokeWidth="1"
+            strokeWidth="1.5"
           />
         </g>
       </svg>
@@ -575,7 +575,7 @@ exports[`Storyshots Data Display/Icon Icons 1`] = `
             d="M9 11L5 8.22222L1 11V2.11111C1 1.81643 1.12041 1.53381 1.33474 1.32544C1.54906 1.11706 1.83975 1 2.14286 1H7.85714C8.16025 1 8.45094 1.11706 8.66527 1.32544C8.87959 1.53381 9 1.81643 9 2.11111V11Z"
             strokeLinecap="round"
             strokeLinejoin="round"
-            strokeWidth="1"
+            strokeWidth="1.5"
           />
         </g>
       </svg>


### PR DESCRIPTION
The stroke in the bookmark icons is too tiny when sm and vivid colors