### PR TITLE
Allow optional children in ButtonLink

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-components",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Gnosis UI components",
   "main": "dist/index.min.js",
   "typings": "dist/index.d.ts",

--- a/src/inputs/ButtonLink/index.tsx
+++ b/src/inputs/ButtonLink/index.tsx
@@ -10,7 +10,7 @@ export interface Props extends React.ComponentPropsWithoutRef<'button'> {
   iconSize?: ThemeIconSize;
   textSize?: ThemeTextSize;
   color: ThemeColors;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }
 
 const StyledButtonLink = styled.button<Props>`


### PR DESCRIPTION
Allow children to be optional in ButtonLink, allowing to create a button with only icon