### PR TITLE
Move from ethereum-blockies-base64 to blo

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "@ethersproject/address": "^5.7.0",
-    "ethereum-blockies-base64": "^1.0.2"
+    "blo": "^1.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.7",

--- a/src/components/EthHashInfo/Identicon.tsx
+++ b/src/components/EthHashInfo/Identicon.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import createIdenticon from 'ethereum-blockies-base64';
+import { blo } from 'blo';
 import Skeleton from '@mui/material/Skeleton';
 import { styled } from '@mui/material/styles';
 
@@ -14,7 +14,7 @@ const Identicon = ({
 }: IdenticonProps): React.ReactElement => {
   const style = React.useMemo<React.CSSProperties | null>(() => {
     try {
-      const icon = createIdenticon(address);
+      const icon = blo(address as `0x${string}`);
       return {
         backgroundImage: `url(${icon})`,
         width: `${size}px`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4242,6 +4242,11 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
+blo@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/blo/-/blo-1.1.1.tgz#ed781c5c516fba484ec8ec86105dc27f6c553209"
+  integrity sha512-1uGZInlRD4X1WQP2G1QjDGwGZ8HdGgFKqnzyRdA2TYYc0MOQCmCi37RTQ8oJuI0UF6DYFKXHwV/t1kZkO/fTaA==
+
 bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
@@ -5999,13 +6004,6 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
-
-ethereum-blockies-base64@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/ethereum-blockies-base64/-/ethereum-blockies-base64-1.0.2.tgz#4aebca52142bf4d16a3144e6e2b59303e39ed2b3"
-  integrity sha512-Vg2HTm7slcWNKaRhCUl/L3b4KrB8ohQXdd5Pu3OI897EcR6tVRvUqdTwAyx+dnmoDzj8e2bwBLDQ50ByFmcz6w==
-  dependencies:
-    pnglib "0.0.1"
 
 events@^3.0.0, events@^3.2.0:
   version "3.3.0"
@@ -9692,11 +9690,6 @@ pkg-dir@^5.0.0:
   integrity sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==
   dependencies:
     find-up "^5.0.0"
-
-pnglib@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/pnglib/-/pnglib-0.0.1.tgz#f9ab6f9c688f4a9d579ad8be28878a716e30c096"
-  integrity sha512-95ChzOoYLOPIyVmL+Y6X+abKGXUJlvOVLkB1QQkyXl7Uczc6FElUy/x01NS7r2GX6GRezloO/ecCX9h4U9KadA==
 
 pnp-webpack-plugin@1.6.4:
   version "1.6.4"


### PR DESCRIPTION
Move from ethereum-blockies-base64 to [blo](https://github.com/bpierre/blo), for a faster (~4.7x) and more precise rendering of the blockies identicons, while also being smaller ([2.75kb](https://bundlejs.com/?bundle&q=ethereum-blockies-base64) => [0.67 KB](https://bundlejs.com/?bundle&q=blo)).

Disclaimer: I am the author of blo.

I couldn’t find how to generate the complete Storybook as mentionned in the README (https://components.safe.global/), the one in the repo only has 3 components so I took screenshots of the `EthHashInfo` component.

Before:
![image](https://github.com/safe-global/safe-react-components/assets/36158/7f97d475-fbaa-4dca-b8eb-137cab6f8acf)

After:
![image](https://github.com/safe-global/safe-react-components/assets/36158/0c56850f-8660-4586-99e8-4a001bb648c4)

Before (browser zoom):
![image](https://github.com/safe-global/safe-react-components/assets/36158/fde66a08-d086-42d8-8bc8-215cf2e64484)

After (browser zoom):
![image](https://github.com/safe-global/safe-react-components/assets/36158/4ce34a08-da13-4c2c-9ab3-f8a1df03d93f)
